### PR TITLE
Disabled CoreProtect Extension

### DIFF
--- a/Plan/extensions/src/main/java/com/djrapitops/plan/extension/implementation/ExtensionRegister.java
+++ b/Plan/extensions/src/main/java/com/djrapitops/plan/extension/implementation/ExtensionRegister.java
@@ -57,7 +57,7 @@ public class ExtensionRegister {
         register(new ASkyBlockExtensionFactory(), ASkyBlockExtensionFactory::createExtension);
         register(new BanManagerExtensionFactory(), BanManagerExtensionFactory::createExtension);
         register(new BuycraftExtensionFactory(), BuycraftExtensionFactory::createExtension);
-        register(new CoreProtectExtensionFactory(), CoreProtectExtensionFactory::createExtension);
+//        register(new CoreProtectExtensionFactory(), CoreProtectExtensionFactory::createExtension);
         register(new DiscordSRVExtensionFactory(), DiscordSRVExtensionFactory::createExtension);
         register(new DKBansExtensionFactory(), DKBansExtensionFactory::createExtension, DKBansExtensionFactory::registerListener);
         register(new DKCoinsExtensionFactory(), DKCoinsExtensionFactory::createExtension, DKCoinsExtensionFactory::registerListener);


### PR DESCRIPTION
CoreProtect API is not designed for fetching all events for a single player for a large time-span, so its usage is to be disabled until a solution can be figured out.

Affects issues:
- Close #1165