### PR TITLE
Allow Plan config directory to be a symlink

### DIFF
--- a/Plan/common/src/main/java/com/djrapitops/plan/settings/config/ConfigWriter.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/settings/config/ConfigWriter.java
@@ -69,7 +69,9 @@ public class ConfigWriter {
         ConfigNode storedParent = writing.parent;
         writing.updateParent(null);
 
-        Files.createDirectories(outputPath.getParent());
+        if (!Files.isDirectory(outputPath.getParent().toRealPath())) {
+            Files.createDirectories(outputPath.getParent());
+        }
         Files.write(outputPath, parseLines(writing), StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE);
 
         writing.updateParent(storedParent);


### PR DESCRIPTION
Currently, if the Plan directory is a symlink, `Files.createDirectories(outputPath.getParent());` fails, causing plan to fail to load. This adds a simple check to see if whatever is located at the Plan path is already a directory. 

Tested these expected cases: 
- Plan is symlink to directory: works
- Plan is missing: Creates dir, works
- Plan is empty directory: works
- Plan is existing directory: works

Also tested these unsupported cases:
- Plan is broken symlink: Plan fails to load with error
```
java.io.FileNotFoundException: Folders could not be created for config file /path/to/plugins/Plan/config.yml
```

- Plan is a file or a symlink to a file: Paper refuses to load the plugin with error
```
[01:33:20 ERROR]: Could not load 'plugins/Plan.jar' in folder 'plugins'
org.bukkit.plugin.InvalidPluginException: Projected datafolder: `plugins/Plan' for Plan v5.0 build %buildNumber% (plugins/Plan.jar) exists and is not a directory
```