### PR TITLE
Use relative path in Player Page button and Server Analysis button

### DIFF
--- a/Plan/common/src/main/resources/assets/plan/web/js/sessionAccordion.js
+++ b/Plan/common/src/main/resources/assets/plan/web/js/sessionAccordion.js
@@ -90,8 +90,8 @@ function createAccordionBody(i, session) {
         createKillsTable(session.player_kills) +
         '</div><div class="col-xs-12  col-sm-12 col-md-6 col-lg-6">' +
         '<div id="worldpie_' + i + '" class="chart-pie"></div>' +
-        '<a href="/player/' + session.player_uuid + '" class="float-right btn bg-blue"><i class="fa fa-user"></i><span> Player Page</span></a>' +
-        (session.network_server ? '<a href="/server/' + session.server_uuid + '" class="float-right btn bg-light-green mr-2"><i class="fa fa-server"></i><span> Server Analysis</span></a>' : '') +
+        '<a href="../player/' + session.player_uuid + '" class="float-right btn bg-blue"><i class="fa fa-user"></i><span> Player Page</span></a>' +
+        (session.network_server ? '<a href="../server/' + session.server_uuid + '" class="float-right btn bg-light-green mr-2"><i class="fa fa-server"></i><span> Server Analysis</span></a>' : '') +
         '</div>' +
         '</div></td></tr>'
 }


### PR DESCRIPTION
If Plan runs with a reverse proxy in sub route.
Player Page button and Server Analysis button on the Sessions page will not work.
It could be fixed by using relative path instead of absolute path on them.