### PR TITLE
Fix typo in DefaultServerInfoFile.yml

### DIFF
--- a/Plan/common/src/main/resources/assets/plan/DefaultServerInfoFile.yml
+++ b/Plan/common/src/main/resources/assets/plan/DefaultServerInfoFile.yml
@@ -1,4 +1,4 @@
 # Changing the UUID in this file will make Plan regard your server as a completely new server
-# Thread with caution.
+# Tread with caution.
 Server:
   UUID:


### PR DESCRIPTION
Fix typo
`thread with caution`
to
`tread with caution`
in DefaultServerInfoFile.yml