### PR TITLE
Fix use of appendLegacy not working on 1.8

### DIFF
--- a/Plan/bukkit/src/main/java/com/djrapitops/plan/commands/use/BukkitPartBuilder.java
+++ b/Plan/bukkit/src/main/java/com/djrapitops/plan/commands/use/BukkitPartBuilder.java
@@ -19,6 +19,7 @@ package com.djrapitops.plan.commands.use;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.apache.commons.text.TextStringBuilder;
 
 import java.util.Arrays;
@@ -43,7 +44,8 @@ class BukkitPartBuilder implements MessageBuilder {
     @Override
     public MessageBuilder addPart(String text) {
         BukkitPartBuilder nextPart = new BukkitPartBuilder(this);
-        nextPart.part.appendLegacy(text);
+        // appendLegacy cannot be used as it was added after 1.8
+        nextPart.part.append(TextComponent.fromLegacyText(text));
         return nextPart;
     }
 


### PR DESCRIPTION
## Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
Fixes https://github.com/plan-player-analytics/Plan/issues/1600 by using `.append(TextComponent.fromLegacyText(...))` which is what the convenience method `.appendLegacy(...)` did
