### PR TITLE
Remove Content-Length related warnings from the server console

### DIFF
--- a/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/ResponseBuilder.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/ResponseBuilder.java
@@ -132,6 +132,10 @@ public class ResponseBuilder {
      */
     public Response build() {
         byte[] content = response.bytes;
+        if(content == null && response.code == 204) {
+            // HTTP Code 204 requires no response, so there is no need to validate it.
+            return response;
+        }
         exceptionIf(content == null, "Content not defined for Response");
         String mimeType = getMimeType();
         exceptionIf(content.length > 0 && mimeType == null, "MIME Type not defined for Response");

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/ResponseResolver.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/ResponseResolver.java
@@ -158,7 +158,7 @@ public class ResponseResolver {
     private Response tryToGetResponse(Request request) {
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS
-            return Response.builder().setStatus(204).setContent(new byte[0]).build();
+            return Response.builder().setStatus(204).build();
         }
 
         Optional<WebUser> user = request.getUser();

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/ResponseSender.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/ResponseSender.java
@@ -45,7 +45,7 @@ public class ResponseSender {
 
     public void send() throws IOException {
         setResponseHeaders();
-        if ("HEAD".equals(exchange.getRequestMethod())) {
+        if ("HEAD".equals(exchange.getRequestMethod()) || response.getCode() == 204) {
             sendHeadResponse();
         } else if ("bytes".equalsIgnoreCase(response.getHeaders().get("Accept-Ranges"))) {
             sendRawBytes();
@@ -91,7 +91,9 @@ public class ResponseSender {
     }
 
     private void beginSend() throws IOException {
-        exchange.sendResponseHeaders(response.getCode(), 0);
+        // Return a content length of -1 for HTTP code 204 (No content)
+        // and HEAD requests to avoid warning messages.
+        exchange.sendResponseHeaders(response.getCode(), (response.getCode() == 204 || "HEAD".equals(exchange.getRequestMethod())) ? -1 : 0);
     }
 
     private void sendRawBytes() throws IOException {


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
Just a small PR that fixes #1605 while I'm still getting used to contributing here. Removes the following warnings from the console:
```java
sendResponseHeaders: rCode = 204: forcing contentLen = -1
```
```java
sendResponseHeaders: being invoked with a content length for a HEAD request
```
I've tested it on a test server and everything works fine. The only thing to worry about is that there is no `Content-Length` header when sending a `HEAD` request, but according to [this StackOverflow answer](https://stackoverflow.com/a/42170178/6672199) including that header is optional.

After this I'm probably going to look at issue 1318: "Browser back button should go back to the previous page." If there is anything else you want me to look into/work on, just let me know, I'd love to help!