### PR TITLE
Allow setting night mode (and other themes) by default in theme.yml

### DIFF
--- a/Plan/common/src/main/resources/assets/plan/web/js/color-selector.js
+++ b/Plan/common/src/main/resources/assets/plan/web/js/color-selector.js
@@ -10,12 +10,8 @@
         'brown', 'grey', 'blue-grey'];
 
     const selectedColor = window.localStorage.getItem('themeColor');
-    const themeDefaultColor = 'plan';
+    const themeDefaultColor = '${defaultTheme}';
     let currentColor = 'plan';
-
-    if (selectedColor === null) {
-        window.localStorage.setItem('themeColor', currentColor);
-    }
 
     // Function for changing color
     function setColor(nextColor) {
@@ -71,7 +67,11 @@
     // Change the color of the theme
     setColor(selectedColor ? selectedColor : themeDefaultColor);
 
-    let nightMode = window.localStorage.getItem('nightMode') == 'true';
+    if (selectedColor === null) {
+        window.localStorage.setItem('themeColor', currentColor);
+    }
+
+    let nightMode = window.localStorage.getItem('nightMode') ? window.localStorage.getItem('nightMode') == 'true' : '${defaultTheme}' == 'night';
 
     const saturationReduction = 0.70;
 

--- a/Plan/common/src/main/resources/assets/plan/web/js/color-selector.js
+++ b/Plan/common/src/main/resources/assets/plan/web/js/color-selector.js
@@ -15,6 +15,9 @@
 
     // Function for changing color
     function setColor(nextColor) {
+        if (selectedColor === null) {
+            window.localStorage.setItem('themeColor', currentColor);
+        }
         $('body').removeClass('theme-' + currentColor).addClass('theme-' + nextColor);
         if (!nextColor || nextColor == currentColor) {
             return;
@@ -67,11 +70,7 @@
     // Change the color of the theme
     setColor(selectedColor ? selectedColor : themeDefaultColor);
 
-    if (selectedColor === null) {
-        window.localStorage.setItem('themeColor', currentColor);
-    }
-
-    let nightMode = window.localStorage.getItem('nightMode') ? window.localStorage.getItem('nightMode') == 'true' : '${defaultTheme}' == 'night';
+    let nightMode = window.localStorage.getItem('nightMode') == 'true' || '${defaultTheme}' == 'night';
 
     const saturationReduction = 0.70;
 


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
This PR makes it so that this code in `theme.yml` enables night mode and sets the theme color to "plan" if night mode is disabled by the user:
```yml
# Default Theme bar color when user has not chosen a color
DefaultColor: "night"
```
I'm not sure if this is the way you want default night mode to be enabled, but it is a really simple solution that works. It also looked like the default theme color in `theme.yml` didn't work at all, or at least it wasn't interpolated into `color-selector.js`, so this PR fixes that as well.

I've also finished #1318, so tell me if you want those changes on this PR or a separate one.