### PR TITLE
Prevent adding new history entries when switching tabs.

### DIFF
--- a/Plan/common/src/main/resources/assets/plan/web/js/sb-admin-2.js
+++ b/Plan/common/src/main/resources/assets/plan/web/js/sb-admin-2.js
@@ -51,13 +51,26 @@ for (let tab of tabs) {
 
 window.addEventListener('hashchange', openPage);
 
+//Sidebar navigation tabs
+$('#accordionSidebar .nav-item a').click(event => {
+    if(history.replaceState) {
+        event.preventDefault();
+        history.replaceState(undefined, undefined, '#' + event.currentTarget.href.split('#')[1]);
+        openPage();
+    }
+});
+
 // Persistent Bootstrap tabs
 $('.nav-tabs a.nav-link').click(event => {
     const uriHash = (window.location.hash).split("&");
     if (!uriHash) return;
     const currentTab = uriHash[0];
     const originalTargetId = event.currentTarget.href.split('#')[1];
-    window.location.hash = currentTab + '&' + originalTargetId;
+    if(history.replaceState) {
+        event.preventDefault();
+        history.replaceState(undefined, undefined, currentTab + '&' + originalTargetId);
+        openPage();
+    } else window.location.hash = currentTab + '&' + originalTargetId;
 });
 
 let oldWidth = null;


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
Fixes #1318 by using `history.replaceState` and preventing the default click event of most `<a>` tags instead of letting the default behavior occur and listening for the `hashchange` event.

We shouldn't have to worry about compatibility because the `history.replaceState` is [widely supported](https://caniuse.com/history) on all modern browsers.