### PR TITLE
Remove special error case for Brave browser

### DIFF
--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
@@ -33,6 +33,7 @@ public class Contributors {
     public static String generateContributorHtml() {
         Contributor[] contributors = new Contributor[]{
                 new Contributor("aidn5", CODE),
+                new Contributor("Antonok", CODE),
                 new Contributor("Argetan", CODE),
                 new Contributor("Aurelien", CODE, LANG),
                 new Contributor("BrainStone", CODE),

--- a/Plan/common/src/main/resources/assets/plan/web/js/xmlhttprequests.js
+++ b/Plan/common/src/main/resources/assets/plan/web/js/xmlhttprequests.js
@@ -24,12 +24,7 @@ function jsonRequest(address, callback) {
                         callback(null, "Request did not reach the server. (Server offline / Adblocker?)")
                     }
                 } catch (e) {
-                    if (e.message.includes('Unexpected end of JSON input') && navigator.brave && navigator.brave.isBrave) {
-                        navigator.brave.isBrave()
-                            .then(confirm => callback(null, e.message + (confirm ? " (Possibly blocked by ad-block in Brave)" : '') + " (See " + address + ")"));
-                    } else {
-                        callback(null, e.message + " (See " + address + ")")
-                    }
+                    callback(null, e.message + " (See " + address + ")")
                 }
             }
         };


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [ ] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
Reverts https://github.com/plan-player-analytics/Plan/commit/b7e1261597a81d7eb29d10059dc6d9ad13026b45 as of https://github.com/plan-player-analytics/Plan/issues/1425#issuecomment-708194444. There was a false positive rule from Easylist that was removed, so Brave and other adblockers no longer prevent the graph from working as intended.

And for future reference, if any functionality isn't working on Brave, feel free to reach out - we're not trying to break cool projects like this one :smile: 