### PR TITLE
locale: fix color code in german translation

### DIFF
--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
@@ -73,6 +73,7 @@ public class Contributors {
                 new Contributor("Karlatemp", CODE, LANG),
                 new Contributor("Mastory_Md5", LANG),
                 new Contributor("FluxCapacitor2", CODE)
+                new Contributor("galexrt", LANG),
         };
         int estimatedLength = contributors.length * 40 + 50;
         StringBuilder html = new StringBuilder(estimatedLength);

--- a/Plan/common/src/main/resources/assets/plan/locale/locale_DE.txt
+++ b/Plan/common/src/main/resources/assets/plan/locale/locale_DE.txt
@@ -96,7 +96,7 @@ Cmd Qinspect - Last Seen                        ||   §2Zuletzt gesehen: §f${0}
 Cmd Qinspect - Longest Session                  ||   §2Längste Session: §f${0}
 Cmd Qinspect - Mob Kills                        ||   §2Getötete Mobs: §f${0}
 Cmd Qinspect - Player Kills                     ||   §2Getötete Spieler: §f${0}
-Cmd Qinspect - Playtime                         ||   §Spielzeit: §f${0}
+Cmd Qinspect - Playtime                         ||   §2Spielzeit: §f${0}
 Cmd Qinspect - Registered                       ||   §2Registrierung: §f${0}
 Cmd Qinspect - Times Kicked                     ||   §2Kicks: §f${0}
 Cmd SUCCESS - Feature disabled                  || §a'${0}' wurde bis zum nächsten Reload des Plugins deaktiviert.


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [ ] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

Should I add myself to the `LangCode.java` file for this small fix?

### Description
This fixes a broken color code for the "Spielerzeit" (playtime) text in the `/plan ingame` output.