### PR TITLE
Fix invalid page loader centering

### DIFF
--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
@@ -72,6 +72,7 @@ public class Contributors {
             new Contributor("QuakyCZ", LANG),
             new Contributor("MrFriggo", LANG),
             new Contributor("vacoup", CODE),
+            new Contributor("Kopo942", CODE),
     };
 
     private Contributors() {

--- a/Plan/common/src/main/resources/assets/plan/web/css/style.css
+++ b/Plan/common/src/main/resources/assets/plan/web/css/style.css
@@ -7,22 +7,25 @@
     text-align: center;
 }
 
+.loader-container {
+    position: relative;
+    top: 50%;
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
+}
+
 .loader {
     display: inline-block;
     width: 2rem;
     height: 2rem;
-    position: absolute;
     border: 4px solid #368F17;
     border-radius: 5px;
-    top: 50%;
     background-color: #368F17;
     animation: loader 2s infinite ease;
 }
 
 .loader-text {
-    position: relative;
-    top: 55%;
-    left: 1rem;
+    margin-top: 0.5rem;
 }
 
 @keyframes loader {

--- a/Plan/common/src/main/resources/assets/plan/web/js/query.js
+++ b/Plan/common/src/main/resources/assets/plan/web/js/query.js
@@ -274,8 +274,10 @@ function runQuery() {
     if (timestamp) {
         document.querySelector('#content .tab').innerHTML =
             `<div class="page-loader">
+            <div class="loader-container">
             <span class="loader"></span>
             <p class="loader-text">Loading..</p>
+            </div>
         </div>`;
     } else {
         const icon = document.createElement('template');

--- a/Plan/common/src/main/resources/assets/plan/web/network.html
+++ b/Plan/common/src/main/resources/assets/plan/web/network.html
@@ -30,8 +30,10 @@
     const gmPieColors = [${gmPieColors}];
 </script>
 <div class="page-loader">
-    <span class="loader"></span>
-    <p class="loader-text">Please wait..</p>
+    <div class="loader-container">
+        <span class="loader"></span>
+        <p class="loader-text">Please wait..</p>
+    </div>
 </div>
 
 <!-- Page Wrapper -->

--- a/Plan/common/src/main/resources/assets/plan/web/player.html
+++ b/Plan/common/src/main/resources/assets/plan/web/player.html
@@ -30,8 +30,10 @@
     var gmPieColors = [${gmPieColors}];
 </script>
 <div class="page-loader">
-    <span class="loader"></span>
-    <p class="loader-text">Please wait..</p>
+    <div class="loader-container">
+        <span class="loader"></span>
+        <p class="loader-text">Please wait..</p>
+    </div>
 </div>
 
 <!-- Page Wrapper -->

--- a/Plan/common/src/main/resources/assets/plan/web/server.html
+++ b/Plan/common/src/main/resources/assets/plan/web/server.html
@@ -28,8 +28,10 @@
     var gmPieColors = [${gmPieColors}];
 </script>
 <div class="page-loader">
-    <span class="loader"></span>
-    <p class="loader-text">Please wait..</p>
+    <div class="loader-container">
+        <span class="loader"></span>
+        <p class="loader-text">Please wait..</p>
+    </div>
 </div>
 
 <!-- Page Wrapper -->


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
Quick & small pull that fixes the invalid centering of the page loader by adding a wrapper div for the icon & text and adjusting the CSS. Closes #1783.

Probably going to tackle some more of Plan's JS & HTML issues in the future, we'll see! I've really gotten into web development lately, and what's a better place to start contributing than a Finnish repo for a game I like! :)
