### PR TITLE
Fixed URL hash handling with graph tabs

### DIFF
--- a/Plan/common/src/main/resources/assets/plan/web/js/sb-admin-2.js
+++ b/Plan/common/src/main/resources/assets/plan/web/js/sb-admin-2.js
@@ -61,16 +61,23 @@ $('#accordionSidebar .nav-item a').click(event => {
 });
 
 // Persistent Bootstrap tabs
-$('.nav-tabs a.nav-link').click(event => {
-    const uriHash = (window.location.hash).split("&");
-    if (!uriHash) return;
-    const currentTab = uriHash[0];
-    const originalTargetId = event.currentTarget.href.split('#')[1];
-    if (history.replaceState) {
-        event.preventDefault();
-        history.replaceState(undefined, undefined, currentTab + '&' + originalTargetId);
-        openPage();
-    } else window.location.hash = currentTab + '&' + originalTargetId;
+document.querySelectorAll(".nav-tabs a.nav-link").forEach(item => {
+    item.addEventListener("click", event => {
+        let uriHash;
+        if (window.location.hash) {
+            uriHash = (window.location.hash).split("&");
+        } else {
+            window.location.hash = document.querySelector(".sidebar a.nav-link").href.split("#")[1]
+            uriHash = [window.location.hash];
+        }
+        const targetTab = event.currentTarget.href.split('#')[1];
+        if (history.replaceState) {
+            event.preventDefault();
+            history.replaceState(undefined, undefined, uriHash[0] + '&' + targetTab);
+            openPage();
+        } else
+            window.location.hash = uriHash[0] + '&' + targetTab;
+    });
 });
 
 let oldWidth = null;


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
Correctly handle the URL hash when changing graph tabs. If a page is loaded but no page hash is supplied (`/network`), get current page hash from active navbar element. Hacky, but it works. Also got rid of jQuery for future-proofness. Fixes #1736.