### PR TITLE
Add a list of servers to the navbar

### DIFF
--- a/Plan/common/src/main/resources/assets/plan/web/css/style.css
+++ b/Plan/common/src/main/resources/assets/plan/web/css/style.css
@@ -758,6 +758,31 @@ div.scrollbar {
     background-color: rgba(0, 0, 0, 0.08);
 }
 
+div#navSrvContainer {
+    overflow-y: auto;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    max-height: 180px;
+}
+
+div#navSrvContainer>a {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+div#navSrvContainer::-webkit-scrollbar {
+    width: 12px;
+}
+
+div#navSrvContainer::-webkit-scrollbar-thumb {
+    border: 4px solid rgba(0, 0, 0, 0);
+    background-clip: padding-box;
+    -webkit-border-radius: 7px;
+    background-color: rgba(0, 0, 0, 0.25);
+    -webkit-box-shadow: inset -1px -1px 0px rgba(0, 0, 0, 0.05), inset 1px 1px 0px rgba(0, 0, 0, 0.05);
+}
+
 .bg-gradient {
     background: rgba(0, 0, 0, 0) linear-gradient(180deg, rgba(0, 0, 0, 0) 20%, rgba(0, 0, 0, 0.2) 100%);
 }

--- a/Plan/common/src/main/resources/assets/plan/web/js/network-values.js
+++ b/Plan/common/src/main/resources/assets/plan/web/js/network-values.js
@@ -231,7 +231,7 @@ function loadPlayerbaseOverviewValues(json, error) {
     element.querySelector('#data_regular_to_inactive').innerHTML = data.regular_to_inactive + smallTrend(data.regular_to_inactive_trend);
 }
 
-function loadservers(json, error) {
+function loadServers(json, error) {
     if (error) {
         displayError(document.getElementById('servers-tab'), error);
         return;
@@ -240,6 +240,8 @@ function loadservers(json, error) {
     const servers = json.servers;
 
     if (!servers || !servers.length) {
+        let elements = document.getElementsByClassName('nav-servers');
+        for (let i = 0; i < elements.length; i++) { elements[i].style.display = 'none'; }
         document.getElementById('game-server-warning').classList.remove('hidden');
         document.getElementById('data_server_list').innerHTML =
             `<div class="card shadow mb-4"><div class="card-body"><p>No servers found in the database.</p><p>It appears that Plan is not installed on any game servers or not connected to the same database. See <a href="https://github.com/plan-player-analytics/Plan/wiki">wiki</a> for Network tutorial.</p></div></div>`
@@ -247,20 +249,28 @@ function loadservers(json, error) {
         return;
     }
 
+    let navServersHtml = '';
     let serversHtml = '';
     for (let i = 0; i < servers.length; i++) {
-        serversHtml += createnetworkserverBox(i, servers[i]);
+        navServersHtml += addServerToNav(servers[i]);
+        serversHtml += createNetworkServerBox(i, servers[i]);
     }
+
+    document.getElementById("navSrvContainer").innerHTML = navServersHtml;
     document.getElementById("data_server_list").innerHTML = serversHtml;
 
     for (let i = 0; i < servers.length; i++) {
         document.getElementById(`server_quick_view_${i}`)
-            .addEventListener('click', onViewserver(i, servers));
+            .addEventListener('click', onViewServer(i, servers));
     }
-    onViewserver(0, servers)(); // Open first server.
+    onViewServer(0, servers)(); // Open first server.
 }
 
-function createnetworkserverBox(i, server) {
+function addServerToNav(server) {
+    return `<a class="collapse-item nav-button" href="server/${server.name}"><i class="fas fa-fw fa-server col-light-green"></i> ${server.name}</a>`;
+}
+
+function createNetworkServerBox(i, server) {
     return `<div class="card shadow mb-4">
                 <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
                     <h6 class="m-0 font-weight-bold col-black">
@@ -282,7 +292,7 @@ function createnetworkserverBox(i, server) {
             </div>`;
 }
 
-function onViewserver(i, servers) {
+function onViewServer(i, servers) {
     return function () {
         setTimeout(function () {
             const server = servers[i];

--- a/Plan/common/src/main/resources/assets/plan/web/js/network-values.js
+++ b/Plan/common/src/main/resources/assets/plan/web/js/network-values.js
@@ -231,7 +231,7 @@ function loadPlayerbaseOverviewValues(json, error) {
     element.querySelector('#data_regular_to_inactive').innerHTML = data.regular_to_inactive + smallTrend(data.regular_to_inactive_trend);
 }
 
-function loadServers(json, error) {
+function loadservers(json, error) {
     if (error) {
         displayError(document.getElementById('servers-tab'), error);
         return;
@@ -252,8 +252,8 @@ function loadServers(json, error) {
     let navServersHtml = '';
     let serversHtml = '';
     for (let i = 0; i < servers.length; i++) {
-        navServersHtml += addServerToNav(servers[i]);
-        serversHtml += createNetworkServerBox(i, servers[i]);
+        navServersHtml += addserverToNav(servers[i]);
+        serversHtml += createnetworkserverBox(i, servers[i]);
     }
 
     document.getElementById("navSrvContainer").innerHTML = navServersHtml;
@@ -261,16 +261,16 @@ function loadServers(json, error) {
 
     for (let i = 0; i < servers.length; i++) {
         document.getElementById(`server_quick_view_${i}`)
-            .addEventListener('click', onViewServer(i, servers));
+            .addEventListener('click', onViewserver(i, servers));
     }
-    onViewServer(0, servers)(); // Open first server.
+    onViewserver(0, servers)(); // Open first server.
 }
 
-function addServerToNav(server) {
+function addserverToNav(server) {
     return `<a class="collapse-item nav-button" href="server/${server.name}"><i class="fas fa-fw fa-server col-light-green"></i> ${server.name}</a>`;
 }
 
-function createNetworkServerBox(i, server) {
+function createnetworkserverBox(i, server) {
     return `<div class="card shadow mb-4">
                 <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
                     <h6 class="m-0 font-weight-bold col-black">
@@ -292,7 +292,7 @@ function createNetworkServerBox(i, server) {
             </div>`;
 }
 
-function onViewServer(i, servers) {
+function onViewserver(i, servers) {
     return function () {
         setTimeout(function () {
             const server = servers[i];

--- a/Plan/common/src/main/resources/assets/plan/web/network.html
+++ b/Plan/common/src/main/resources/assets/plan/web/network.html
@@ -73,7 +73,7 @@
                     <a class="collapse-item nav-button" href="#tab-sessions-overview"><i
                             class="far fa-fw fa-calendar-alt"></i>
                         Sessions</a>
-                    <hr class="nav-servers sidebar-divider my-2">
+                    <hr class="nav-servers dropdown-divider mx-3 my-2">
                     <div class="nav-servers" id="navSrvContainer">
                     </div>
                 </div>

--- a/Plan/common/src/main/resources/assets/plan/web/network.html
+++ b/Plan/common/src/main/resources/assets/plan/web/network.html
@@ -73,6 +73,9 @@
                     <a class="collapse-item nav-button" href="#tab-sessions-overview"><i
                             class="far fa-fw fa-calendar-alt"></i>
                         Sessions</a>
+                    <hr class="nav-servers sidebar-divider my-2">
+                    <div class="nav-servers" id="navSrvContainer">
+                    </div>
                 </div>
             </div>
         </li>
@@ -904,7 +907,7 @@
 
         setLoadingText('Calculating values..');
         refreshingJsonRequest("./v1/network/overview", loadNetworkOverviewValues, 'network-overview');
-        refreshingJsonRequest("./v1/network/servers", loadservers, 'servers');
+        refreshingJsonRequest("./v1/network/servers", loadServers, 'servers');
         refreshingJsonRequest("./v1/network/sessionsOverview", loadSessionValues, 'sessions-overview');
         refreshingJsonRequest("./v1/network/playerbaseOverview", loadPlayerbaseOverviewValues, 'playerbase-overview');
         refreshingJsonRequest("./v1/sessions", loadSessionAccordion, 'sessions-overview');

--- a/Plan/common/src/main/resources/assets/plan/web/network.html
+++ b/Plan/common/src/main/resources/assets/plan/web/network.html
@@ -907,7 +907,7 @@
 
         setLoadingText('Calculating values..');
         refreshingJsonRequest("./v1/network/overview", loadNetworkOverviewValues, 'network-overview');
-        refreshingJsonRequest("./v1/network/servers", loadServers, 'servers');
+        refreshingJsonRequest("./v1/network/servers", loadservers, 'servers');
         refreshingJsonRequest("./v1/network/sessionsOverview", loadSessionValues, 'sessions-overview');
         refreshingJsonRequest("./v1/network/playerbaseOverview", loadPlayerbaseOverviewValues, 'playerbase-overview');
         refreshingJsonRequest("./v1/sessions", loadSessionAccordion, 'sessions-overview');


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
Adds a list of servers to the navbar, fixes some irregularities with JS function names. The list shows about five servers by default before the scrollbar is shown. Text wrapping for long server names included.

Closes #1790.

Ref:
![image](https://user-images.githubusercontent.com/13612979/111696583-26301500-883d-11eb-92f7-de7f55e5f7e3.png)