### PR TITLE
Added "_raw" placeholder variants for further processing

### DIFF
--- a/Plan/common/src/main/java/com/djrapitops/plan/placeholder/PlayerPlaceHolders.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/placeholder/PlayerPlaceHolders.java
@@ -164,15 +164,27 @@ public class PlayerPlaceHolders implements Placeholders {
                 player -> time.apply(SessionsMutator.forContainer(player)
                         .toActivePlaytime())
         );
+        placeholders.register("player_time_active_raw",
+                player -> SessionsMutator.forContainer(player)
+                        .toActivePlaytime()
+        );
 
         placeholders.register("player_time_afk",
                 player -> time.apply(SessionsMutator.forContainer(player)
                         .toAfkTime())
         );
+        placeholders.register("player_time_afk_raw",
+                player -> SessionsMutator.forContainer(player)
+                        .toAfkTime()
+        );
 
         placeholders.register("player_time_total",
                 player -> time.apply(SessionsMutator.forContainer(player)
                         .toPlaytime())
+        );
+        placeholders.register("player_time_total_raw",
+                player -> SessionsMutator.forContainer(player)
+                        .toPlaytime()
         );
 
         placeholders.register("player_time_day",
@@ -180,14 +192,29 @@ public class PlayerPlaceHolders implements Placeholders {
                         .filterSessionsBetween(dayAgo(), now())
                         .toPlaytime())
         );
+        placeholders.register("player_time_day_raw",
+                player -> SessionsMutator.forContainer(player)
+                        .filterSessionsBetween(dayAgo(), now())
+                        .toPlaytime()
+        );
 
         placeholders.register("player_time_week",
                 player -> time.apply(SessionsMutator.forContainer(player)
                         .filterSessionsBetween(weekAgo(), now())
                         .toPlaytime())
         );
+        placeholders.register("player_time_week_raw",
+                player -> SessionsMutator.forContainer(player)
+                        .filterSessionsBetween(weekAgo(), now())
+                        .toPlaytime()
+        );
 
         placeholders.register("player_time_month",
+                player -> time.apply(SessionsMutator.forContainer(player)
+                        .filterSessionsBetween(monthAgo(), now())
+                        .toPlaytime())
+        );
+        placeholders.register("player_time_month_raw",
                 player -> time.apply(SessionsMutator.forContainer(player)
                         .filterSessionsBetween(monthAgo(), now())
                         .toPlaytime())
@@ -198,17 +225,32 @@ public class PlayerPlaceHolders implements Placeholders {
                         .filterPlayedOnServer(serverInfo.getServerUUID())
                         .toActivePlaytime())
         );
+        placeholders.register("player_server_time_active_raw",
+                player -> time.apply(SessionsMutator.forContainer(player)
+                        .filterPlayedOnServer(serverInfo.getServerUUID())
+                        .toActivePlaytime())
+        );
 
         placeholders.register("player_server_time_afk",
                 player -> time.apply(SessionsMutator.forContainer(player)
                         .filterPlayedOnServer(serverInfo.getServerUUID())
                         .toAfkTime())
         );
+        placeholders.register("player_server_time_afk_raw",
+                player -> SessionsMutator.forContainer(player)
+                        .filterPlayedOnServer(serverInfo.getServerUUID())
+                        .toAfkTime()
+        );
 
         placeholders.register("player_server_time_total",
                 player -> time.apply(SessionsMutator.forContainer(player)
                         .filterPlayedOnServer(serverInfo.getServerUUID())
                         .toPlaytime())
+        );
+        placeholders.register("player_server_time_total_raw",
+                player -> SessionsMutator.forContainer(player)
+                        .filterPlayedOnServer(serverInfo.getServerUUID())
+                        .toPlaytime()
         );
 
         placeholders.register("player_server_time_day",
@@ -217,6 +259,12 @@ public class PlayerPlaceHolders implements Placeholders {
                         .filterPlayedOnServer(serverInfo.getServerUUID())
                         .toPlaytime())
         );
+        placeholders.register("player_server_time_day_raw",
+                player -> SessionsMutator.forContainer(player)
+                        .filterSessionsBetween(dayAgo(), now())
+                        .filterPlayedOnServer(serverInfo.getServerUUID())
+                        .toPlaytime()
+        );
 
         placeholders.register("player_server_time_week",
                 player -> time.apply(SessionsMutator.forContainer(player)
@@ -224,12 +272,24 @@ public class PlayerPlaceHolders implements Placeholders {
                         .filterPlayedOnServer(serverInfo.getServerUUID())
                         .toPlaytime())
         );
+        placeholders.register("player_server_time_week_raw",
+                player -> SessionsMutator.forContainer(player)
+                        .filterSessionsBetween(weekAgo(), now())
+                        .filterPlayedOnServer(serverInfo.getServerUUID())
+                        .toPlaytime()
+        );
 
         placeholders.register("player_server_time_month",
                 player -> time.apply(SessionsMutator.forContainer(player)
                         .filterSessionsBetween(monthAgo(), now())
                         .filterPlayedOnServer(serverInfo.getServerUUID())
                         .toPlaytime())
+        );
+        placeholders.register("player_server_time_month_raw",
+                player -> SessionsMutator.forContainer(player)
+                        .filterSessionsBetween(monthAgo(), now())
+                        .filterPlayedOnServer(serverInfo.getServerUUID())
+                        .toPlaytime()
         );
     }
 }

--- a/Plan/common/src/main/java/com/djrapitops/plan/placeholder/SessionPlaceHolders.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/placeholder/SessionPlaceHolders.java
@@ -84,30 +84,54 @@ public class SessionPlaceHolders implements Placeholders {
 
         placeholders.registerStatic("sessions_play_time_total",
                 () -> timeAmount.apply(database.query(SessionQueries.playtime(0L, now(), serverUUID))));
+        placeholders.registerStatic("sessions_play_time_total_raw",
+                () -> database.query(SessionQueries.playtime(0L, now(), serverUUID)));
         placeholders.registerStatic("sessions_play_time_day",
                 () -> timeAmount.apply(database.query(SessionQueries.playtime(dayAgo(), now(), serverUUID))));
+        placeholders.registerStatic("sessions_play_time_day_raw",
+                () -> database.query(SessionQueries.playtime(dayAgo(), now(), serverUUID)));
         placeholders.registerStatic("sessions_play_time_week",
                 () -> timeAmount.apply(database.query(SessionQueries.playtime(weekAgo(), now(), serverUUID))));
+        placeholders.registerStatic("sessions_play_time_week_raw",
+                () -> database.query(SessionQueries.playtime(weekAgo(), now(), serverUUID)));
         placeholders.registerStatic("sessions_play_time_month",
                 () -> timeAmount.apply(database.query(SessionQueries.playtime(monthAgo(), now(), serverUUID))));
+        placeholders.registerStatic("sessions_play_time_month_raw",
+                () -> database.query(SessionQueries.playtime(monthAgo(), now(), serverUUID)));
 
         placeholders.registerStatic("sessions_active_time_total",
                 () -> timeAmount.apply(database.query(SessionQueries.activePlaytime(0L, now(), serverUUID))));
+        placeholders.registerStatic("sessions_active_time_total_raw",
+                () -> database.query(SessionQueries.activePlaytime(0L, now(), serverUUID)));
         placeholders.registerStatic("sessions_active_time_day",
                 () -> timeAmount.apply(database.query(SessionQueries.activePlaytime(dayAgo(), now(), serverUUID))));
+        placeholders.registerStatic("sessions_active_time_day_raw",
+                () -> database.query(SessionQueries.activePlaytime(dayAgo(), now(), serverUUID)));
         placeholders.registerStatic("sessions_active_time_week",
                 () -> timeAmount.apply(database.query(SessionQueries.activePlaytime(weekAgo(), now(), serverUUID))));
+        placeholders.registerStatic("sessions_active_time_week_raw",
+                () -> database.query(SessionQueries.activePlaytime(weekAgo(), now(), serverUUID)));
         placeholders.registerStatic("sessions_active_time_month",
                 () -> timeAmount.apply(database.query(SessionQueries.activePlaytime(monthAgo(), now(), serverUUID))));
+        placeholders.registerStatic("sessions_active_time_month_raw",
+                () -> database.query(SessionQueries.activePlaytime(monthAgo(), now(), serverUUID)));
 
         placeholders.registerStatic("sessions_afk_time_total",
                 () -> timeAmount.apply(database.query(SessionQueries.afkTime(0L, now(), serverUUID))));
+        placeholders.registerStatic("sessions_afk_time_total_raw",
+                () -> database.query(SessionQueries.afkTime(0L, now(), serverUUID)));
         placeholders.registerStatic("sessions_afk_time_day",
                 () -> timeAmount.apply(database.query(SessionQueries.afkTime(dayAgo(), now(), serverUUID))));
+        placeholders.registerStatic("sessions_afk_time_day_raw",
+                () -> database.query(SessionQueries.afkTime(dayAgo(), now(), serverUUID)));
         placeholders.registerStatic("sessions_afk_time_week",
                 () -> timeAmount.apply(database.query(SessionQueries.afkTime(weekAgo(), now(), serverUUID))));
+        placeholders.registerStatic("sessions_afk_time_week_raw",
+                () -> database.query(SessionQueries.afkTime(weekAgo(), now(), serverUUID)));
         placeholders.registerStatic("sessions_afk_time_month",
                 () -> timeAmount.apply(database.query(SessionQueries.afkTime(monthAgo(), now(), serverUUID))));
+        placeholders.registerStatic("sessions_afk_time_month_raw",
+                () -> database.query(SessionQueries.afkTime(monthAgo(), now(), serverUUID)));
 
         Supplier<Serializable> uniquePlayers = () -> database.query(PlayerCountQueries.newPlayerCount(0L, now(), serverUUID));
         placeholders.registerStatic("sessions_unique_players_total", uniquePlayers);


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [X] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [X] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
Added raw time placeholders that just give you the raw ms value of any time based placeholder instead of the nicely formatted ones.

These placeholders can be more easily used to be processed in plugins that process placeholders (like scoreboards).
