### PR TITLE
Fixes log-in logo being stretched on Safari

### DIFF
--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
@@ -75,6 +75,7 @@ public class Contributors {
             new Contributor("Kopo942", CODE),
             new Contributor("WolverStones", LANG),
             new Contributor("BruilsiozPro", LANG),
+            new Contributor("AppleMacOS", CODE),
     };
 
     private Contributors() {

--- a/Plan/common/src/main/resources/assets/plan/web/css/sb-admin-2.css
+++ b/Plan/common/src/main/resources/assets/plan/web/css/sb-admin-2.css
@@ -199,7 +199,6 @@ figure {
 }
 
 img {
-    height: auto;
     vertical-align: middle;
     border-style: none;
 }

--- a/Plan/common/src/main/resources/assets/plan/web/css/style.css
+++ b/Plan/common/src/main/resources/assets/plan/web/css/style.css
@@ -28,6 +28,7 @@
 
 .w-15 {
     width: 15% !important;
+    height: 50%;
 }
 
 .w-22 {


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [ ] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description

This pull request fixes the log-in screen logo being stretched on Safari.