### PR TITLE
Add Velocity 3.0.0 support

### DIFF
--- a/Plan/build.gradle
+++ b/Plan/build.gradle
@@ -73,7 +73,7 @@ subprojects {
         spongeVersion = "7.3.0"
         nukkitVersion = "1.0-SNAPSHOT"
         bungeeVersion = "1.16-R0.4"
-        velocityVersion = "1.0.0-SNAPSHOT"
+        velocityVersion = "3.0.0-SNAPSHOT"
         redisBungeeVersion = "0.6.3"
 
         commonsTextVersion = "1.9"

--- a/Plan/velocity/src/main/java/com/djrapitops/plan/PlanVelocity.java
+++ b/Plan/velocity/src/main/java/com/djrapitops/plan/PlanVelocity.java
@@ -23,6 +23,7 @@ import com.djrapitops.plan.exceptions.EnableException;
 import com.djrapitops.plan.settings.locale.Locale;
 import com.djrapitops.plan.settings.locale.lang.PluginLang;
 import com.djrapitops.plan.settings.theme.PlanColorScheme;
+import com.velocitypowered.api.command.CommandManager;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
@@ -146,9 +147,12 @@ public class PlanVelocity implements PlanPlugin {
             logger.warn("Attempted to register a null command!");
             return;
         }
-        proxy.getCommandManager().register(
-                new VelocityCommand(runnableFactory, system.getErrorLogger(), command),
-                command.getAliases().toArray(new String[0])
+        CommandManager commandManager = proxy.getCommandManager();
+        commandManager.register(
+                commandManager.metaBuilder(command.getPrimaryAlias())
+                        .aliases(command.getAliases().toArray(new String[0]))
+                        .build(),
+                new VelocityCommand(runnableFactory, system.getErrorLogger(), command)
         );
     }
 

--- a/Plan/velocity/src/main/java/com/djrapitops/plan/commands/use/VelocityCMDSender.java
+++ b/Plan/velocity/src/main/java/com/djrapitops/plan/commands/use/VelocityCMDSender.java
@@ -17,7 +17,7 @@
 package com.djrapitops.plan.commands.use;
 
 import com.velocitypowered.api.command.CommandSource;
-import net.kyori.text.TextComponent;
+import net.kyori.adventure.text.Component;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -53,7 +53,7 @@ public class VelocityCMDSender implements CMDSender {
 
     @Override
     public void send(String message) {
-        commandSource.sendMessage(TextComponent.of(message));
+        commandSource.sendMessage(Component.text(message));
     }
 
     @Override

--- a/Plan/velocity/src/main/java/com/djrapitops/plan/commands/use/VelocityCommand.java
+++ b/Plan/velocity/src/main/java/com/djrapitops/plan/commands/use/VelocityCommand.java
@@ -18,8 +18,8 @@ package com.djrapitops.plan.commands.use;
 
 import com.djrapitops.plan.utilities.logging.ErrorContext;
 import com.djrapitops.plan.utilities.logging.ErrorLogger;
-import com.velocitypowered.api.command.Command;
 import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
 import com.velocitypowered.api.proxy.Player;
 import net.playeranalytics.plugin.scheduling.RunnableFactory;
 
@@ -27,7 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class VelocityCommand implements Command {
+public class VelocityCommand implements SimpleCommand {
 
     private final RunnableFactory runnableFactory;
     private final ErrorLogger errorLogger;
@@ -40,7 +40,9 @@ public class VelocityCommand implements Command {
     }
 
     @Override
-    public void execute(CommandSource source, String[] args) {
+    public void execute(final Invocation invocation) {
+        CommandSource source = invocation.source();
+        String[] args = invocation.arguments();
         runnableFactory.create(() -> {
             try {
                 command.getExecutor().accept(getSender(source), new Arguments(args));
@@ -62,7 +64,9 @@ public class VelocityCommand implements Command {
     }
 
     @Override
-    public List<String> suggest(CommandSource source, String[] currentArgs) {
+    public List<String> suggest(final Invocation invocation) {
+        CommandSource source = invocation.source();
+        String[] currentArgs = invocation.arguments();
         try {
             return command.getArgumentResolver().apply(getSender(source), new Arguments(currentArgs));
         } catch (Exception e) {

--- a/Plan/velocity/src/main/java/com/djrapitops/plan/commands/use/VelocityMessageBuilder.java
+++ b/Plan/velocity/src/main/java/com/djrapitops/plan/commands/use/VelocityMessageBuilder.java
@@ -16,9 +16,10 @@
  */
 package com.djrapitops.plan.commands.use;
 
-import net.kyori.text.TextComponent;
-import net.kyori.text.event.ClickEvent;
-import net.kyori.text.event.HoverEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
 import org.apache.commons.text.TextStringBuilder;
 
 import java.util.Collection;
@@ -26,65 +27,65 @@ import java.util.Collection;
 public class VelocityMessageBuilder implements MessageBuilder {
 
     private final VelocityCMDSender sender;
-    private TextComponent.Builder builder;
+    private final TextComponent.Builder builder;
 
     public VelocityMessageBuilder(VelocityCMDSender sender) {
         this.sender = sender;
-        builder = TextComponent.builder();
+        builder = Component.text();
     }
 
     @Override
     public MessageBuilder addPart(String content) {
-        builder = builder.append(content);
+        builder.append(Component.text(content));
         return this;
     }
 
     @Override
     public MessageBuilder newLine() {
-        builder = builder.append("\n");
+        builder.append(Component.text("\n"));
         return this;
     }
 
     @Override
     public MessageBuilder link(String url) {
-        builder = builder.clickEvent(ClickEvent.openUrl(url));
+        builder.clickEvent(ClickEvent.openUrl(url));
         return this;
     }
 
     @Override
     public MessageBuilder command(String command) {
-        builder = builder.clickEvent(ClickEvent.runCommand(command));
+        builder.clickEvent(ClickEvent.runCommand(command));
         return this;
     }
 
     @Override
     public MessageBuilder hover(String s) {
-        builder = builder.hoverEvent(HoverEvent.showText(TextComponent.of(s)));
+        builder.hoverEvent(HoverEvent.showText(Component.text(s)));
         return this;
     }
 
     @Override
     public MessageBuilder hover(String... strings) {
-        TextComponent.Builder hoverText = TextComponent.builder();
+        TextComponent.Builder hoverText = Component.text();
         for (String string : strings) {
-            hoverText.append(string);
+            hoverText.append(Component.text(string));
         }
-        builder = builder.hoverEvent(HoverEvent.showText(hoverText.build()));
+        builder.hoverEvent(HoverEvent.showText(hoverText.build()));
         return this;
     }
 
     @Override
     public MessageBuilder hover(Collection<String> lines) {
-        TextComponent.Builder hoverText = TextComponent.builder();
-        hoverText.append(new TextStringBuilder().appendWithSeparators(lines, "\n").build());
-        builder = builder.hoverEvent(HoverEvent.showText(hoverText.build()));
+        TextComponent.Builder hoverText = Component.text();
+        hoverText.append(Component.text(new TextStringBuilder().appendWithSeparators(lines, "\n").build()));
+        builder.hoverEvent(HoverEvent.showText(hoverText.build()));
         return this;
     }
 
     @Override
     public MessageBuilder indent(int amount) {
         for (int i = 0; i < amount; i++) {
-            builder = builder.append(" ");
+            builder.append(Component.text(" "));
         }
         return this;
     }


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
- Switched `VelocityCommand` implementation to `SimpleCommand` subinterface
- Removed old & deprecated `text` component handling API in favor of Adventure components

Tested working on Velocity 3.0.0, backwards compatibility tested on Velocity 1.1.8 (console only). Fixes #1957.