### PR TITLE
Use globally unique plugin ID for plugin cards with tabs

### DIFF
--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
@@ -82,7 +82,8 @@ public class Contributors {
             new Contributor("4drian3d", LANG),
             new Contributor("\u6d1b\u4f0a", LANG),
             new Contributor("portlek", CODE),
-            new Contributor("mbax", CODE)
+            new Contributor("mbax", CODE),
+            new Contributor("rymiel", CODE)
     };
 
     private Contributors() {

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/structure/TabsElement.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/structure/TabsElement.java
@@ -26,9 +26,11 @@ import org.apache.commons.lang3.RegExUtils;
  */
 public class TabsElement {
 
+    private final int pluginId;
     private final Tab[] tabs;
 
-    public TabsElement(Tab... tabs) {
+    public TabsElement(int pluginId, Tab... tabs) {
+        this.pluginId = pluginId;
         this.tabs = tabs;
     }
 
@@ -45,7 +47,7 @@ public class TabsElement {
         content.append("<div class=\"tab-content\">");
         boolean first = true;
         for (Tab tab : tabs) {
-            String id = tab.getId();
+            String id = tab.getId(pluginId);
             String navHtml = tab.getNavHtml();
             String contentHtml = tab.getContentHtml();
 
@@ -83,8 +85,8 @@ public class TabsElement {
             return contentHtml;
         }
 
-        public String getId() {
-            return "tab_" + RegExUtils.removeAll(title, "[^a-zA-Z0-9]*").toLowerCase();
+        public String getId(int pluginId) {
+            return "tab_" + pluginId + "_" + RegExUtils.removeAll(title, "[^a-zA-Z0-9]*").toLowerCase();
         }
     }
 }

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/pages/PlayerPluginTab.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/pages/PlayerPluginTab.java
@@ -112,6 +112,7 @@ public class PlayerPluginTab implements Comparable<PlayerPluginTab> {
                 tabsElement = buildContentHtml(genericTabData);
             } else {
                 tabsElement = new TabsElement(
+                        datum.getPluginID(),
                         datum.getTabs().stream().map(this::wrapToTabElementTab).toArray(TabsElement.Tab[]::new)
                 ).toHtmlFull();
             }

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/pages/ServerPluginTabs.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/pages/ServerPluginTabs.java
@@ -112,6 +112,7 @@ public class ServerPluginTabs {
                 tabsElement = buildContentHtml(genericTabData);
             } else {
                 tabsElement = new TabsElement(
+                        datum.getPluginID(),
                         datum.getTabs().stream().map(this::wrapToTabElementTab).toArray(TabsElement.Tab[]::new)
                 ).toHtmlFull();
             }
@@ -137,6 +138,7 @@ public class ServerPluginTabs {
                 tabsElement = buildContentHtml(genericTabData);
             } else {
                 tabsElement = new TabsElement(
+                        datum.getPluginID(),
                         datum.getTabs().stream().map(this::wrapToTabElementTab).toArray(TabsElement.Tab[]::new)
                 ).toHtmlFull();
             }


### PR DESCRIPTION
Fixes #1982

Plugin ID is passed in together with `#getId()` to avoid it in every initializer to `Tab`. Clearly not the best solution but i wanted to make a contribution