### PR TITLE
Use POST method in requests such as login

### DIFF
--- a/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
@@ -119,7 +119,14 @@ public final class Request {
             return lazyFormBody;
         }
 
-        lazyFormBody = new URIQuery(new String(body));
+        if (
+                method.equalsIgnoreCase("POST") &&
+                getHeader("Content-type").orElse("").equalsIgnoreCase("application/x-www-form-urlencoded")
+        ) {
+            lazyFormBody = new URIQuery(new String(body));
+        } else {
+            lazyFormBody = new URIQuery("");
+        }
         return lazyFormBody;
     }
 

--- a/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
@@ -120,8 +120,8 @@ public final class Request {
         }
 
         if (
-                method.equalsIgnoreCase("POST") &&
-                getHeader("Content-type").orElse("").equalsIgnoreCase("application/x-www-form-urlencoded")
+                "POST".equalsIgnoreCase(method) &&
+                "application/x-www-form-urlencoded".equalsIgnoreCase(getHeader("Content-type").orElse(""))
         ) {
             lazyFormBody = new URIQuery(new String(body));
         } else {

--- a/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
@@ -55,7 +55,9 @@ public final class Request {
         this.body = body;
     }
 
-    // Special constructor that figures out URIPath and URIQuery from "/path/and?query=params" and has no form body
+    /**
+     * Special constructor that figures out URIPath and URIQuery from "/path/and?query=params" and has no form body.
+     */
     public Request(String method, String target, WebUser user, Map<String, String> headers) {
         this.method = method;
         if (target.contains("?")) {

--- a/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
@@ -36,8 +36,6 @@ public final class Request {
     private final Map<String, String> headers;
     private final byte[] body;
 
-    private URIQuery lazyFormBody = null;
-
     /**
      * Constructor.
      *
@@ -107,27 +105,6 @@ public final class Request {
      */
     public byte[] getRequestBody() {
         return body;
-    }
-
-    /**
-     * Get the body as an url-encoded form, if present.
-     *
-     * @return {@link URIQuery}.
-     */
-    public URIQuery getFormBody() {
-        if (lazyFormBody != null) {
-            return lazyFormBody;
-        }
-
-        if (
-                "POST".equalsIgnoreCase(method) &&
-                "application/x-www-form-urlencoded".equalsIgnoreCase(getHeader("Content-type").orElse(""))
-        ) {
-            lazyFormBody = new URIQuery(new String(body));
-        } else {
-            lazyFormBody = new URIQuery("");
-        }
-        return lazyFormBody;
     }
 
     /**

--- a/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
@@ -34,25 +34,28 @@ public final class Request {
     private final URIQuery query;
     private final WebUser user;
     private final Map<String, String> headers;
+    private final URIQuery formBody;
 
     /**
      * Constructor.
      *
-     * @param method  HTTP method, GET, PUT, POST, etc
-     * @param path    Requested path /example/target
-     * @param query   Request parameters ?param=value etc
-     * @param user    Web user doing the request (if authenticated)
-     * @param headers Request headers https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
+     * @param method   HTTP method, GET, PUT, POST, etc
+     * @param path     Requested path /example/target
+     * @param query    Request parameters ?param=value etc
+     * @param user     Web user doing the request (if authenticated)
+     * @param headers  Request headers https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
+     * @param formBody Map representation of application/x-www-form-urlencoded POST data, if present
      */
-    public Request(String method, URIPath path, URIQuery query, WebUser user, Map<String, String> headers) {
+    public Request(String method, URIPath path, URIQuery query, WebUser user, Map<String, String> headers, URIQuery formBody) {
         this.method = method;
         this.path = path;
         this.query = query;
         this.user = user;
         this.headers = headers;
+        this.formBody = formBody;
     }
 
-    // Special constructor that figures out URIPath and URIQuery from "/path/and?query=params"
+    // Special constructor that figures out URIPath and URIQuery from "/path/and?query=params" and has no form body
     public Request(String method, String target, WebUser user, Map<String, String> headers) {
         this.method = method;
         if (target.contains("?")) {
@@ -65,6 +68,7 @@ public final class Request {
         }
         this.user = user;
         this.headers = headers;
+        this.formBody = new URIQuery("");
     }
 
     /**
@@ -95,6 +99,15 @@ public final class Request {
     }
 
     /**
+     * Get the POST Form body, if present.
+     *
+     * @return {@link URIQuery}.
+     */
+    public Optional<URIQuery> getFormBody() {
+        return Optional.ofNullable(formBody);
+    }
+
+    /**
      * Get the user making the request.
      *
      * @return the user if authentication is enabled
@@ -114,7 +127,7 @@ public final class Request {
     }
 
     public Request omitFirstInPath() {
-        return new Request(method, path.omitFirst(), query, user, headers);
+        return new Request(method, path.omitFirst(), query, user, headers, formBody);
     }
 
     @Override
@@ -125,6 +138,7 @@ public final class Request {
                 ", query=" + query +
                 ", user=" + user +
                 ", headers=" + headers +
+                ", formBody=" + formBody +
                 '}';
     }
 }

--- a/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
@@ -105,7 +105,7 @@ public final class Request {
      *
      * @return byte[].
      */
-    public byte[] getRawBody() {
+    public byte[] getRequestBody() {
         return body;
     }
 
@@ -161,7 +161,7 @@ public final class Request {
                 ", query=" + query +
                 ", user=" + user +
                 ", headers=" + headers +
-                ", body=" + body +
+                ", body=" + body.length +
                 '}';
     }
 }

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/RequestBodyConverter.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/RequestBodyConverter.java
@@ -1,0 +1,22 @@
+package com.djrapitops.plan.delivery.webserver;
+
+import com.djrapitops.plan.delivery.web.resolver.request.Request;
+import com.djrapitops.plan.delivery.web.resolver.request.URIQuery;
+
+public class RequestBodyConverter {
+  /**
+   * Get the body of a request as an url-encoded form.
+   *
+   * @return {@link URIQuery}.
+   */
+  public static URIQuery formBody(Request request) {
+    if (
+        "POST".equalsIgnoreCase(request.getMethod()) &&
+            "application/x-www-form-urlencoded".equalsIgnoreCase(request.getHeader("Content-type").orElse(""))
+    ) {
+      return new URIQuery(new String(request.getRequestBody()));
+    } else {
+      return new URIQuery("");
+    }
+  }
+}

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/RequestBodyConverter.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/RequestBodyConverter.java
@@ -1,3 +1,19 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.djrapitops.plan.delivery.webserver;
 
 import com.djrapitops.plan.delivery.web.resolver.request.Request;

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/RequestHandler.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/RequestHandler.java
@@ -190,21 +190,16 @@ public class RequestHandler implements HttpHandler {
         URIPath path = new URIPath(exchange.getRequestURI().getPath());
         URIQuery query = new URIQuery(exchange.getRequestURI().getRawQuery());
         byte[] requestBody = new byte[0];
-        if (
-                exchange.getRequestMethod().equalsIgnoreCase("POST") &&
-                exchange.getRequestHeaders().getFirst("Content-Type").equalsIgnoreCase("application/x-www-form-urlencoded")
-        ) {
-            try {
-                int b;
-                ByteArrayOutputStream buf = new ByteArrayOutputStream(512);
-                while ((b = exchange.getRequestBody().read()) != -1) {
-                    buf.write((byte) b);
-                }
-
-                requestBody = buf.toByteArray();
-            } catch (IOException ignored) {
-                // requestBody stays empty
+        try {
+            int b;
+            ByteArrayOutputStream buf = new ByteArrayOutputStream(512);
+            while ((b = exchange.getRequestBody().read()) != -1) {
+                buf.write((byte) b);
             }
+
+            requestBody = buf.toByteArray();
+        } catch (IOException ignored) {
+            // requestBody stays empty
         }
         WebUser user = getWebUser(exchange);
         Map<String, String> headers = getRequestHeaders(exchange);

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/RequestHandler.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/RequestHandler.java
@@ -41,6 +41,7 @@ import org.apache.commons.text.TextStringBuilder;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -188,24 +189,23 @@ public class RequestHandler implements HttpHandler {
         String requestMethod = exchange.getRequestMethod();
         URIPath path = new URIPath(exchange.getRequestURI().getPath());
         URIQuery query = new URIQuery(exchange.getRequestURI().getRawQuery());
-        URIQuery requestBody = null;
+        byte[] requestBody = new byte[0];
         if (
                 exchange.getRequestMethod().equalsIgnoreCase("POST") &&
                 exchange.getRequestHeaders().getFirst("Content-Type").equalsIgnoreCase("application/x-www-form-urlencoded")
         ) {
             try {
                 int b;
-                StringBuilder buf = new StringBuilder(512);
+                ByteArrayOutputStream buf = new ByteArrayOutputStream(512);
                 while ((b = exchange.getRequestBody().read()) != -1) {
-                    buf.append((char) b);
+                    buf.write((byte) b);
                 }
 
-                requestBody = new URIQuery(buf.toString());
+                requestBody = buf.toByteArray();
             } catch (IOException ignored) {
                 // requestBody stays empty
             }
         }
-        System.out.print(requestBody);
         WebUser user = getWebUser(exchange);
         Map<String, String> headers = getRequestHeaders(exchange);
         return new Request(requestMethod, path, query, user, headers, requestBody);

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/RequestHandler.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/RequestHandler.java
@@ -190,9 +190,8 @@ public class RequestHandler implements HttpHandler {
         URIPath path = new URIPath(exchange.getRequestURI().getPath());
         URIQuery query = new URIQuery(exchange.getRequestURI().getRawQuery());
         byte[] requestBody = new byte[0];
-        try {
+        try (ByteArrayOutputStream buf = new ByteArrayOutputStream(512)) {
             int b;
-            ByteArrayOutputStream buf = new ByteArrayOutputStream(512);
             while ((b = exchange.getRequestBody().read()) != -1) {
                 buf.write((byte) b);
             }

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/resolver/auth/LoginResolver.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/resolver/auth/LoginResolver.java
@@ -22,6 +22,7 @@ import com.djrapitops.plan.delivery.web.resolver.Response;
 import com.djrapitops.plan.delivery.web.resolver.exception.BadRequestException;
 import com.djrapitops.plan.delivery.web.resolver.request.Request;
 import com.djrapitops.plan.delivery.web.resolver.request.URIQuery;
+import com.djrapitops.plan.delivery.webserver.RequestBodyConverter;
 import com.djrapitops.plan.delivery.webserver.auth.ActiveCookieStore;
 import com.djrapitops.plan.delivery.webserver.auth.FailReason;
 import com.djrapitops.plan.exceptions.PassEncryptException;
@@ -69,7 +70,7 @@ public class LoginResolver implements NoAuthResolver {
     }
 
     public User getUser(Request request) {
-        URIQuery form = request.getFormBody();
+        URIQuery form = RequestBodyConverter.formBody(request);
         String username = form.get("user").orElseThrow(() -> new BadRequestException("'user' parameter not defined"));
         String password = form.get("password").orElseThrow(() -> new BadRequestException("'password' parameter not defined"));
         User user = dbSystem.getDatabase().query(WebUserQueries.fetchUser(username))

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/resolver/auth/LoginResolver.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/resolver/auth/LoginResolver.java
@@ -69,9 +69,9 @@ public class LoginResolver implements NoAuthResolver {
     }
 
     public User getUser(Request request) {
-        URIQuery query = request.getQuery();
-        String username = query.get("user").orElseThrow(() -> new BadRequestException("'user' parameter not defined"));
-        String password = query.get("password").orElseThrow(() -> new BadRequestException("'password' parameter not defined"));
+        URIQuery form = request.getFormBody().orElseThrow(() -> new BadRequestException("POST body not supplied, login must use POST method"));
+        String username = form.get("user").orElseThrow(() -> new BadRequestException("'user' parameter not defined"));
+        String password = form.get("password").orElseThrow(() -> new BadRequestException("'password' parameter not defined"));
         User user = dbSystem.getDatabase().query(WebUserQueries.fetchUser(username))
                 .orElseThrow(() -> new WebUserAuthException(FailReason.USER_PASS_MISMATCH));
 

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/resolver/auth/LoginResolver.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/resolver/auth/LoginResolver.java
@@ -69,7 +69,7 @@ public class LoginResolver implements NoAuthResolver {
     }
 
     public User getUser(Request request) {
-        URIQuery form = request.getFormBody().orElseThrow(() -> new BadRequestException("POST body not supplied, login must use POST method"));
+        URIQuery form = request.getFormBody();
         String username = form.get("user").orElseThrow(() -> new BadRequestException("'user' parameter not defined"));
         String password = form.get("password").orElseThrow(() -> new BadRequestException("'password' parameter not defined"));
         User user = dbSystem.getDatabase().query(WebUserQueries.fetchUser(username))

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/resolver/auth/RegisterResolver.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/resolver/auth/RegisterResolver.java
@@ -55,12 +55,13 @@ public class RegisterResolver implements NoAuthResolver {
                     .build();
         }
 
-        String username = query.get("user").orElseThrow(() -> new BadRequestException("'user' parameter not defined"));
+        URIQuery form = request.getFormBody();
+        String username = form.get("user").orElseThrow(() -> new BadRequestException("'user' parameter not defined"));
 
         boolean alreadyExists = dbSystem.getDatabase().query(WebUserQueries.fetchUser(username)).isPresent();
         if (alreadyExists) throw new BadRequestException("User already exists!");
 
-        String password = query.get("password").orElseThrow(() -> new BadRequestException("'password' parameter not defined"));
+        String password = form.get("password").orElseThrow(() -> new BadRequestException("'password' parameter not defined"));
         try {
             String code = RegistrationBin.addInfoForRegistration(username, password);
             return Response.builder()

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/resolver/auth/RegisterResolver.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/resolver/auth/RegisterResolver.java
@@ -21,6 +21,7 @@ import com.djrapitops.plan.delivery.web.resolver.Response;
 import com.djrapitops.plan.delivery.web.resolver.exception.BadRequestException;
 import com.djrapitops.plan.delivery.web.resolver.request.Request;
 import com.djrapitops.plan.delivery.web.resolver.request.URIQuery;
+import com.djrapitops.plan.delivery.webserver.RequestBodyConverter;
 import com.djrapitops.plan.delivery.webserver.auth.RegistrationBin;
 import com.djrapitops.plan.storage.database.DBSystem;
 import com.djrapitops.plan.storage.database.queries.objects.WebUserQueries;
@@ -55,7 +56,7 @@ public class RegisterResolver implements NoAuthResolver {
                     .build();
         }
 
-        URIQuery form = request.getFormBody();
+        URIQuery form = RequestBodyConverter.formBody(request);
         String username = form.get("user").orElseThrow(() -> new BadRequestException("'user' parameter not defined"));
 
         boolean alreadyExists = dbSystem.getDatabase().query(WebUserQueries.fetchUser(username)).isPresent();

--- a/Plan/common/src/main/resources/assets/plan/web/js/xmlhttprequests.js
+++ b/Plan/common/src/main/resources/assets/plan/web/js/xmlhttprequests.js
@@ -56,45 +56,68 @@ function refreshingJsonRequest(address, callback, tabID, skipOldData) {
 }
 
 /**
- * Make an XMLHttpRequest for JSON data.
+ * Make a GET XMLHttpRequest for JSON data.
  * @param address Address to request from
  * @param callback function with (json, error) parameters to call after the request.
- * @param postBody If supplied, use POST method instead of GET.
  */
-function jsonRequest(address, callback, postBody) {
+function jsonRequest(address, callback) {
     setTimeout(function () {
-        const xhr = new XMLHttpRequest();
-        const usingPostMethod = postBody !== undefined;
-        xhr.withCredentials = true;
-        xhr.onreadystatechange = function () {
-            if (this.readyState === 4) {
-                try {
-                    if (this.status === 200 || (this.status === 0 && this.responseText)) {
-                        var json = JSON.parse(this.responseText);
-                        setTimeout(function () {
-                            callback(json, null)
-                        }, 0);
-                    } else if (this.status === 404 || this.status === 403 || this.status === 500) {
-                        callback(null, "HTTP " + this.status + " (See " + address + ")")
-                    } else if (this.status === 400) {
-                        const json = JSON.parse(this.responseText);
-                        callback(json, json.error)
-                    } else if (this.status === 0) {
-                        callback(null, "Request did not reach the server. (Server offline / Adblocker?)")
-                    }
-                } catch (e) {
-                    callback(null, e.message + " (See " + address + ")")
-                }
-            }
-        };
-        xhr.timeout = 45000;
-        xhr.ontimeout = function () {
-            callback(null, "Timed out after 45 seconds. (" + address + ")")
-        };
-        xhr.open(usingPostMethod ? "POST" : "GET", address, true);
-        if (usingPostMethod) {
-            xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-        }
-        xhr.send(usingPostMethod ? postBody : null);
+        const xhr = newConfiguredXHR(callback);
+
+        xhr.open("GET", address, true);
+        xhr.send();
     }, 0);
+}
+
+/**
+ * Make a POST XMLHttpRequest for JSON data.
+ * @param address Address to request from
+ * @param postBody POST body (form).
+ * @param callback function with (json, error) parameters to call after the request.
+ */
+function jsonPostRequest(address, postBody, callback) {
+    setTimeout(function () {
+        const xhr = newConfiguredXHR(callback);
+
+        xhr.open("POST", address, true);
+        xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+        xhr.send(postBody);
+    }, 0);
+}
+
+/**
+ * Create new XMLHttpRequest configured for methods such as jsonRequest
+ * @param callback function with (json, error) parameters to call after the request.
+ */
+function newConfiguredXHR(callback) {
+    const xhr = new XMLHttpRequest();
+
+    xhr.withCredentials = true;
+    xhr.onreadystatechange = function () {
+        if (this.readyState === 4) {
+            try {
+                if (this.status === 200 || (this.status === 0 && this.responseText)) {
+                    var json = JSON.parse(this.responseText);
+                    setTimeout(function () {
+                        callback(json, null)
+                    }, 0);
+                } else if (this.status === 404 || this.status === 403 || this.status === 500) {
+                    callback(null, "HTTP " + this.status + " (See " + address + ")")
+                } else if (this.status === 400) {
+                    const json = JSON.parse(this.responseText);
+                    callback(json, json.error)
+                } else if (this.status === 0) {
+                    callback(null, "Request did not reach the server. (Server offline / Adblocker?)")
+                }
+            } catch (e) {
+                callback(null, e.message + " (See " + address + ")")
+            }
+        }
+    };
+    xhr.timeout = 45000;
+    xhr.ontimeout = function () {
+        callback(null, "Timed out after 45 seconds. (" + address + ")")
+    };
+
+    return xhr;
 }

--- a/Plan/common/src/main/resources/assets/plan/web/js/xmlhttprequests.js
+++ b/Plan/common/src/main/resources/assets/plan/web/js/xmlhttprequests.js
@@ -59,10 +59,12 @@ function refreshingJsonRequest(address, callback, tabID, skipOldData) {
  * Make an XMLHttpRequest for JSON data.
  * @param address Address to request from
  * @param callback function with (json, error) parameters to call after the request.
+ * @param postBody If supplied, use POST method instead of GET.
  */
-function jsonRequest(address, callback) {
+function jsonRequest(address, callback, postBody) {
     setTimeout(function () {
         const xhr = new XMLHttpRequest();
+        const usingPostMethod = postBody !== undefined;
         xhr.withCredentials = true;
         xhr.onreadystatechange = function () {
             if (this.readyState === 4) {
@@ -89,7 +91,10 @@ function jsonRequest(address, callback) {
         xhr.ontimeout = function () {
             callback(null, "Timed out after 45 seconds. (" + address + ")")
         };
-        xhr.open("GET", address, true);
-        xhr.send();
+        xhr.open(usingPostMethod ? "POST" : "GET", address, true);
+        if (usingPostMethod) {
+            xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+        }
+        xhr.send(usingPostMethod ? postBody : null);
     }, 0);
 }

--- a/Plan/common/src/main/resources/assets/plan/web/login.html
+++ b/Plan/common/src/main/resources/assets/plan/web/login.html
@@ -41,7 +41,7 @@
         if (!password || password.length < 1) {
             return displayError('You need to specify a Password');
         }
-        jsonRequest(`./auth/login`, (json, error) => {
+        jsonPostRequest(`./auth/login`, `user=${encodeURIComponent(user)}&password=${encodeURIComponent(password)}`, (json, error) => {
             if (error) {
                 if (error.includes("HTTP 403")) {
                     location.reload();
@@ -60,7 +60,7 @@
             } else {
                 return displayError('Login failed: ' + json.error);
             }
-        }, `user=${encodeURIComponent(user)}&password=${encodeURIComponent(password)}`);
+        });
     }
 
     document.addEventListener('keydown', (event) => {

--- a/Plan/common/src/main/resources/assets/plan/web/login.html
+++ b/Plan/common/src/main/resources/assets/plan/web/login.html
@@ -41,7 +41,7 @@
         if (!password || password.length < 1) {
             return displayError('You need to specify a Password');
         }
-        jsonRequest(`./auth/login?user=${encodeURIComponent(user)}&password=${encodeURIComponent(password)}`, (json, error) => {
+        jsonRequest(`./auth/login`, (json, error) => {
             if (error) {
                 if (error.includes("HTTP 403")) {
                     location.reload();
@@ -60,7 +60,7 @@
             } else {
                 return displayError('Login failed: ' + json.error);
             }
-        });
+        }, `user=${encodeURIComponent(user)}&password=${encodeURIComponent(password)}`);
     }
 
     document.addEventListener('keydown', (event) => {

--- a/Plan/common/src/main/resources/assets/plan/web/register.html
+++ b/Plan/common/src/main/resources/assets/plan/web/register.html
@@ -217,7 +217,7 @@
         if (!password || password.length < 1) {
             return displayError('You need to specify a Password');
         }
-        jsonRequest(`./auth/register?user=${encodeURIComponent(user)}&password=${encodeURIComponent(password)}`, (json, error) => {
+        jsonPostRequest(`./auth/register`, `user=${encodeURIComponent(user)}&password=${encodeURIComponent(password)}`, (json, error) => {
             if (error) {
                 return displayError('Registration failed: ' + error);
             }

--- a/Plan/common/src/test/java/com/djrapitops/plan/delivery/webserver/AccessControlTest.java
+++ b/Plan/common/src/test/java/com/djrapitops/plan/delivery/webserver/AccessControlTest.java
@@ -126,7 +126,9 @@ public class AccessControlTest {
         HttpURLConnection loginConnection = null;
         String cookie = "";
         try {
-            loginConnection = CONNECTOR.getConnection("GET", address + "/auth/login?user=" + username + "&password=testPass");
+            loginConnection = CONNECTOR.getConnection("POST", address + "/auth/login");
+            loginConnection.setDoOutput(true);
+            loginConnection.getOutputStream().write(("user=" + username + "&password=testPass").getBytes());
             try (InputStream in = loginConnection.getInputStream()) {
                 String responseBody = new String(IOUtils.toByteArray(in));
                 assertTrue(responseBody.contains("\"success\":true"), () -> "Not successful: " + responseBody);

--- a/Plan/common/src/test/java/com/djrapitops/plan/delivery/webserver/HttpsServerTest.java
+++ b/Plan/common/src/test/java/com/djrapitops/plan/delivery/webserver/HttpsServerTest.java
@@ -90,7 +90,9 @@ interface HttpsServerTest {
         HttpURLConnection loginConnection = null;
         String cookie = "";
         try {
-            loginConnection = connector.getConnection("GET", address + "/auth/login?user=test&password=testPass");
+            loginConnection = connector.getConnection("POST", address + "/auth/login");
+            loginConnection.setDoOutput(true);
+            loginConnection.getOutputStream().write("user=test&password=testPass".getBytes());
             try (InputStream in = loginConnection.getInputStream()) {
                 String responseBody = new String(IOUtils.toByteArray(in));
                 assertTrue(responseBody.contains("\"success\":true"), () -> "Not successful: " + responseBody);


### PR DESCRIPTION
May potentially alleviate some security concerns as query parameters are easy to log (such as in reverse proxy logs) and would previously contain cleartext passwords. Plus, logins "_traditionally_" use POST methods since the time of HTTP forms.

Since `x-www-form-urlencoded` is pretty much identical to query parameters which are parsed by the `URIQuery` class, i've used the same exact class to parse the form body.

This is a draft as
1. Only /auth/login is affected, this could probably be extended to other pages such as register (but it is easy to do so)
2. It may be incomplete
3. I don't even know if this is a desired change

Also, I understand that this change would probably be made obsolete by #1987 