### PR TITLE
Implement SlimJar as a runtime dependency downloader

### DIFF
--- a/Plan/build.gradle
+++ b/Plan/build.gradle
@@ -7,8 +7,8 @@ buildscript {
 }
 
 plugins {
-    id "com.github.johnrengelman.shadow" version "7.0.0"
-    id "io.github.slimjar" version "1.2.1"
+    id "com.github.johnrengelman.shadow" version "7.0.0" apply false
+    id "io.github.slimjar" version "1.2.1" apply false
     id "java"
     id "jacoco"
     id "checkstyle"
@@ -42,6 +42,10 @@ allprojects {
     compileJava { options.encoding = "UTF-8" }
     tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
     javadoc { options.encoding = 'UTF-8' }
+
+    repositories {
+        maven { url = "https://repo.vshnv.tech/snapshots" }
+    }
 }
 
 logger.lifecycle("Building artifact for version $fullVersion")

--- a/Plan/build.gradle
+++ b/Plan/build.gradle
@@ -8,6 +8,7 @@ buildscript {
 
 plugins {
     id "com.github.johnrengelman.shadow" version "7.0.0"
+    id "io.github.slimjar" version "1.2.1"
     id "java"
     id "jacoco"
     id "checkstyle"
@@ -48,6 +49,7 @@ logger.lifecycle("Building artifact for version $fullVersion")
 subprojects {
     // Build plugins
     apply plugin: "com.github.johnrengelman.shadow"
+    apply plugin: "io.github.slimjar"
     apply plugin: "java"
     apply plugin: "maven-publish"
 

--- a/Plan/build.gradle
+++ b/Plan/build.gradle
@@ -42,10 +42,6 @@ allprojects {
     compileJava { options.encoding = "UTF-8" }
     tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
     javadoc { options.encoding = 'UTF-8' }
-
-    repositories {
-        maven { url = "https://repo.vshnv.tech/snapshots" }
-    }
 }
 
 logger.lifecycle("Building artifact for version $fullVersion")

--- a/Plan/bukkit/src/main/java/com/djrapitops/plan/Plan.java
+++ b/Plan/bukkit/src/main/java/com/djrapitops/plan/Plan.java
@@ -69,7 +69,10 @@ public class Plan extends JavaPlugin implements PlanPlugin {
 
         getLogger().log(Level.INFO, "Loading dependencies, this might take a while...");
         try {
-            ApplicationBuilder.appending("Plan").downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries")).build();
+            ApplicationBuilder.appending("Plan")
+                    .logger((message, args) -> getLogger().log(Level.INFO, message, args))
+                    .downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries"))
+                    .build();
         } catch (IOException | ReflectiveOperationException | URISyntaxException | NoSuchAlgorithmException e) {
             String version = abstractionLayer.getPluginInformation().getVersion();
             getLogger().log(Level.SEVERE, e, () -> this.getClass().getSimpleName() + "-v" + version);

--- a/Plan/bukkit/src/main/java/com/djrapitops/plan/Plan.java
+++ b/Plan/bukkit/src/main/java/com/djrapitops/plan/Plan.java
@@ -25,6 +25,7 @@ import com.djrapitops.plan.gathering.ServerShutdownSave;
 import com.djrapitops.plan.settings.locale.Locale;
 import com.djrapitops.plan.settings.locale.lang.PluginLang;
 import com.djrapitops.plan.settings.theme.PlanColorScheme;
+import io.github.slimjar.app.builder.ApplicationBuilder;
 import net.playeranalytics.plugin.BukkitPlatformLayer;
 import net.playeranalytics.plugin.PlatformAbstractionLayer;
 import net.playeranalytics.plugin.scheduling.RunnableFactory;
@@ -34,6 +35,10 @@ import org.bukkit.command.PluginCommand;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -61,6 +66,17 @@ public class Plan extends JavaPlugin implements PlanPlugin {
         abstractionLayer = new BukkitPlatformLayer(this);
         pluginLogger = abstractionLayer.getPluginLogger();
         runnableFactory = abstractionLayer.getRunnableFactory();
+
+        getLogger().log(Level.INFO, "Loading dependencies, this might take a while...");
+        try {
+            ApplicationBuilder.appending("Plan").downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries")).build();
+        } catch (IOException | ReflectiveOperationException | URISyntaxException | NoSuchAlgorithmException e) {
+            String version = abstractionLayer.getPluginInformation().getVersion();
+            getLogger().log(Level.SEVERE, e, () -> this.getClass().getSimpleName() + "-v" + version);
+            getLogger().log(Level.SEVERE, "Plan failed to load its dependencies correctly!");
+            getLogger().log(Level.SEVERE, "This error should be reported at https://github.com/plan-player-analytics/Plan/issues");
+            onDisable();
+        }
     }
 
     @Override

--- a/Plan/bungeecord/src/main/java/com/djrapitops/plan/PlanBungee.java
+++ b/Plan/bungeecord/src/main/java/com/djrapitops/plan/PlanBungee.java
@@ -23,13 +23,18 @@ import com.djrapitops.plan.exceptions.EnableException;
 import com.djrapitops.plan.settings.locale.Locale;
 import com.djrapitops.plan.settings.locale.lang.PluginLang;
 import com.djrapitops.plan.settings.theme.PlanColorScheme;
+import io.github.slimjar.app.builder.ApplicationBuilder;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.playeranalytics.plugin.BungeePlatformLayer;
 import net.playeranalytics.plugin.PlatformAbstractionLayer;
 import net.playeranalytics.plugin.scheduling.RunnableFactory;
 import net.playeranalytics.plugin.server.PluginLogger;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -52,6 +57,17 @@ public class PlanBungee extends Plugin implements PlanPlugin {
         abstractionLayer = new BungeePlatformLayer(this);
         logger = abstractionLayer.getPluginLogger();
         runnableFactory = abstractionLayer.getRunnableFactory();
+
+        getLogger().log(Level.INFO, "Loading dependencies, this might take a while...");
+        try {
+            ApplicationBuilder.appending("Plan").downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries")).build();
+        } catch (IOException | ReflectiveOperationException | URISyntaxException | NoSuchAlgorithmException e) {
+            String version = abstractionLayer.getPluginInformation().getVersion();
+            getLogger().log(Level.SEVERE, e, () -> this.getClass().getSimpleName() + "-v" + version);
+            getLogger().log(Level.SEVERE, "Plan failed to load its dependencies correctly!");
+            getLogger().log(Level.SEVERE, "This error should be reported at https://github.com/plan-player-analytics/Plan/issues");
+            onDisable();
+        }
     }
 
     @Override

--- a/Plan/bungeecord/src/main/java/com/djrapitops/plan/PlanBungee.java
+++ b/Plan/bungeecord/src/main/java/com/djrapitops/plan/PlanBungee.java
@@ -60,7 +60,10 @@ public class PlanBungee extends Plugin implements PlanPlugin {
 
         getLogger().log(Level.INFO, "Loading dependencies, this might take a while...");
         try {
-            ApplicationBuilder.appending("Plan").downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries")).build();
+            ApplicationBuilder.appending("Plan")
+                    .logger((message, args) -> getLogger().log(Level.INFO, message, args))
+                    .downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries"))
+                    .build();
         } catch (IOException | ReflectiveOperationException | URISyntaxException | NoSuchAlgorithmException e) {
             String version = abstractionLayer.getPluginInformation().getVersion();
             getLogger().log(Level.SEVERE, e, () -> this.getClass().getSimpleName() + "-v" + version);

--- a/Plan/common/build.gradle
+++ b/Plan/common/build.gradle
@@ -6,8 +6,8 @@ dependencies {
     implementation "org.apache.commons:commons-text:$commonsTextVersion"
     implementation "org.apache.commons:commons-compress:$commonsCompressVersion"
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
-    implementation "mysql:mysql-connector-java:$mysqlVersion"
-    implementation "org.xerial:sqlite-jdbc:$sqliteVersion"
+    compileOnly "mysql:mysql-connector-java:$mysqlVersion"
+    compileOnly "org.xerial:sqlite-jdbc:$sqliteVersion"
     implementation "com.zaxxer:HikariCP:$hikariVersion"
     implementation "org.slf4j:slf4j-nop:$slf4jVersion"
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
@@ -75,8 +75,6 @@ shadowJar {
     // Exclude unnecessary SQLite drivers
     exclude '**/Linux/android-arm/libsqlitejdbc.so'
     exclude '**/DragonFlyBSD/**/libsqlitejdbc.so'
-
-    relocate 'com.google.protobuf', 'plan.com.mysql.cj.x.google.protobuf'
 
     relocate 'com.maxmind', 'plan.com.maxmind'
     relocate 'com.fasterxml', 'plan.com.fasterxml'

--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/upkeep/OldDependencyCacheDeletionTask.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/upkeep/OldDependencyCacheDeletionTask.java
@@ -35,7 +35,6 @@ public class OldDependencyCacheDeletionTask extends TaskSystem.Task {
 
     private final File oldDependencyCache;
     private final File dependencyCache;
-    private final File libraries;
 
     private final ErrorLogger errorLogger;
 
@@ -46,7 +45,6 @@ public class OldDependencyCacheDeletionTask extends TaskSystem.Task {
     ) {
         oldDependencyCache = files.getDataDirectory().resolve("dependency_cache").toFile();
         dependencyCache = files.getDataDirectory().resolve("dep_cache").toFile();
-        libraries = files.getDataDirectory().resolve("libraries").toFile();
         this.errorLogger = errorLogger;
     }
 
@@ -60,7 +58,6 @@ public class OldDependencyCacheDeletionTask extends TaskSystem.Task {
     public void run() {
         tryToDeleteDirectory(oldDependencyCache);
         tryToDeleteDirectory(dependencyCache);
-        tryToDeleteDirectory(libraries);
     }
 
     private void tryToDeleteDirectory(File directory) {

--- a/Plan/gradle.properties
+++ b/Plan/gradle.properties
@@ -1,1 +1,1 @@
-slimjar.version=1.2.5-SNAPSHOT
+slimjar.version=1.2.5

--- a/Plan/gradle.properties
+++ b/Plan/gradle.properties
@@ -1,0 +1,1 @@
+slimjar.version = 1.2.3

--- a/Plan/gradle.properties
+++ b/Plan/gradle.properties
@@ -1,1 +1,1 @@
-slimjar.version = 1.2.3
+slimjar.version=1.2.4

--- a/Plan/gradle.properties
+++ b/Plan/gradle.properties
@@ -1,1 +1,1 @@
-slimjar.version=1.2.4
+slimjar.version=1.2.5-SNAPSHOT

--- a/Plan/nukkit/src/main/java/com/djrapitops/plan/PlanNukkit.java
+++ b/Plan/nukkit/src/main/java/com/djrapitops/plan/PlanNukkit.java
@@ -74,7 +74,10 @@ public class PlanNukkit extends PluginBase implements PlanPlugin {
 
         getLogger().info( "Loading dependencies, this might take a while...");
         try {
-            ApplicationBuilder.appending("Plan").downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries")).build();
+            ApplicationBuilder.appending("Plan")
+                    .logger((message, args) -> Logger.getGlobal().log(Level.INFO, message, args))
+                    .downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries"))
+                    .build();
         } catch (IOException | ReflectiveOperationException | URISyntaxException | NoSuchAlgorithmException e) {
             String version = abstractionLayer.getPluginInformation().getVersion();
             Logger.getGlobal().log(Level.SEVERE, e, () -> this.getClass().getSimpleName() + "-v" + version);

--- a/Plan/nukkit/src/main/java/com/djrapitops/plan/PlanNukkit.java
+++ b/Plan/nukkit/src/main/java/com/djrapitops/plan/PlanNukkit.java
@@ -29,11 +29,16 @@ import com.djrapitops.plan.settings.locale.Locale;
 import com.djrapitops.plan.settings.locale.lang.PluginLang;
 import com.djrapitops.plan.settings.theme.PlanColorScheme;
 import com.djrapitops.plan.utilities.logging.ErrorContext;
+import io.github.slimjar.app.builder.ApplicationBuilder;
 import net.playeranalytics.plugin.NukkitPlatformLayer;
 import net.playeranalytics.plugin.PlatformAbstractionLayer;
 import net.playeranalytics.plugin.scheduling.RunnableFactory;
 import net.playeranalytics.plugin.server.PluginLogger;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -66,6 +71,17 @@ public class PlanNukkit extends PluginBase implements PlanPlugin {
         abstractionLayer = new NukkitPlatformLayer(this);
         logger = abstractionLayer.getPluginLogger();
         runnableFactory = abstractionLayer.getRunnableFactory();
+
+        getLogger().info( "Loading dependencies, this might take a while...");
+        try {
+            ApplicationBuilder.appending("Plan").downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries")).build();
+        } catch (IOException | ReflectiveOperationException | URISyntaxException | NoSuchAlgorithmException e) {
+            String version = abstractionLayer.getPluginInformation().getVersion();
+            Logger.getGlobal().log(Level.SEVERE, e, () -> this.getClass().getSimpleName() + "-v" + version);
+            getLogger().error("Plan failed to load its dependencies correctly!");
+            getLogger().error( "This error should be reported at https://github.com/plan-player-analytics/Plan/issues");
+            onDisable();
+        }
     }
 
     @Override

--- a/Plan/plugin/build.gradle
+++ b/Plan/plugin/build.gradle
@@ -11,6 +11,14 @@ dependencies {
     testImplementation project(path: ":sponge", configuration: 'testArtifacts')
     testImplementation project(path: ":bungeecord", configuration: 'testArtifacts')
     testImplementation project(path: ":velocity", configuration: 'testArtifacts')
+
+    slim "mysql:mysql-connector-java:$mysqlVersion"
+    slim "org.xerial:sqlite-jdbc:$sqliteVersion"
+}
+
+slimJar {
+    relocate 'com.mysql', 'plan.com.mysql'
+    relocate 'com.google.protobuf', 'plan.com.mysql.cj.x.google.protobuf'
 }
 
 shadowJar {
@@ -18,7 +26,6 @@ shadowJar {
         exclude 'org/apache/logging/**'
     }
     relocate 'dagger', 'plan.dagger'
-    relocate 'com.mysql', 'plan.com.mysql'
     // Don't relocate SQLite since the org.sqlite.NativeDB class calls are not relocated properly
     // relocate 'org.sqlite', 'plan.org.sqlite'
     relocate 'javax.inject', 'plan.javax.inject'

--- a/Plan/sponge/src/main/java/com/djrapitops/plan/PlanSponge.java
+++ b/Plan/sponge/src/main/java/com/djrapitops/plan/PlanSponge.java
@@ -123,7 +123,10 @@ public class PlanSponge implements PlanPlugin {
 
         logger.info("Loading dependencies, this might take a while...");
         try {
-            ApplicationBuilder.appending("Plan").downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries")).build();
+            ApplicationBuilder.appending("Plan")
+                    .logger((message, args) -> java.util.logging.Logger.getGlobal().log(Level.INFO, message, args))
+                    .downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries"))
+                    .build();
         } catch (IOException | ReflectiveOperationException | URISyntaxException | NoSuchAlgorithmException e) {
             String version = abstractionLayer.getPluginInformation().getVersion();
             java.util.logging.Logger.getGlobal().log(Level.SEVERE, e, () -> this.getClass().getSimpleName() + "-v" + version);

--- a/Plan/sponge/src/main/java/com/djrapitops/plan/PlanSponge.java
+++ b/Plan/sponge/src/main/java/com/djrapitops/plan/PlanSponge.java
@@ -24,6 +24,7 @@ import com.djrapitops.plan.gathering.ServerShutdownSave;
 import com.djrapitops.plan.settings.locale.Locale;
 import com.djrapitops.plan.settings.locale.lang.PluginLang;
 import com.djrapitops.plan.settings.theme.PlanColorScheme;
+import io.github.slimjar.app.builder.ApplicationBuilder;
 import net.playeranalytics.plugin.PlatformAbstractionLayer;
 import net.playeranalytics.plugin.SpongePlatformLayer;
 import net.playeranalytics.plugin.scheduling.RunnableFactory;
@@ -44,7 +45,11 @@ import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.scheduler.Task;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -115,6 +120,17 @@ public class PlanSponge implements PlanPlugin {
         abstractionLayer = new SpongePlatformLayer(this, dataFolder, slf4jLogger);
         logger = abstractionLayer.getPluginLogger();
         runnableFactory = abstractionLayer.getRunnableFactory();
+
+        logger.info("Loading dependencies, this might take a while...");
+        try {
+            ApplicationBuilder.appending("Plan").downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries")).build();
+        } catch (IOException | ReflectiveOperationException | URISyntaxException | NoSuchAlgorithmException e) {
+            String version = abstractionLayer.getPluginInformation().getVersion();
+            java.util.logging.Logger.getGlobal().log(Level.SEVERE, e, () -> this.getClass().getSimpleName() + "-v" + version);
+            logger.error("Plan failed to load its dependencies correctly!");
+            logger.error("This error should be reported at https://github.com/plan-player-analytics/Plan/issues");
+            onDisable();
+        }
     }
 
     public void onEnable() {

--- a/Plan/velocity/src/main/java/com/djrapitops/plan/PlanVelocity.java
+++ b/Plan/velocity/src/main/java/com/djrapitops/plan/PlanVelocity.java
@@ -31,6 +31,7 @@ import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
+import io.github.slimjar.app.builder.ApplicationBuilder;
 import net.playeranalytics.plugin.PlatformAbstractionLayer;
 import net.playeranalytics.plugin.VelocityPlatformLayer;
 import net.playeranalytics.plugin.scheduling.RunnableFactory;
@@ -39,8 +40,12 @@ import org.bstats.velocity.Metrics;
 import org.slf4j.Logger;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
 import java.util.logging.Level;
 
 /**
@@ -98,6 +103,17 @@ public class PlanVelocity implements PlanPlugin {
         PlatformAbstractionLayer abstractionLayer = new VelocityPlatformLayer(this, proxy, slf4jLogger, dataFolderPath);
         logger = abstractionLayer.getPluginLogger();
         runnableFactory = abstractionLayer.getRunnableFactory();
+
+        logger.info("Loading dependencies, this might take a while...");
+        try {
+            ApplicationBuilder.appending("Plan").downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries")).build();
+        } catch (IOException | ReflectiveOperationException | URISyntaxException | NoSuchAlgorithmException e) {
+            String version = abstractionLayer.getPluginInformation().getVersion();
+            java.util.logging.Logger.getGlobal().log(Level.SEVERE, e, () -> this.getClass().getSimpleName() + "-v" + version);
+            logger.error("Plan failed to load its dependencies correctly!");
+            logger.error("This error should be reported at https://github.com/plan-player-analytics/Plan/issues");
+            onDisable();
+        }
 
         PlanVelocityComponent component = DaggerPlanVelocityComponent.builder()
                 .plan(this)

--- a/Plan/velocity/src/main/java/com/djrapitops/plan/PlanVelocity.java
+++ b/Plan/velocity/src/main/java/com/djrapitops/plan/PlanVelocity.java
@@ -106,7 +106,10 @@ public class PlanVelocity implements PlanPlugin {
 
         logger.info("Loading dependencies, this might take a while...");
         try {
-            ApplicationBuilder.appending("Plan").downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries")).build();
+            ApplicationBuilder.appending("Plan")
+                    .logger((message, args) -> java.util.logging.Logger.getGlobal().log(Level.INFO, message, args))
+                    .downloadDirectoryPath(Paths.get(getDataFolder().getAbsolutePath()).resolve("libraries"))
+                    .build();
         } catch (IOException | ReflectiveOperationException | URISyntaxException | NoSuchAlgorithmException e) {
             String version = abstractionLayer.getPluginInformation().getVersion();
             java.util.logging.Logger.getGlobal().log(Level.SEVERE, e, () -> this.getClass().getSimpleName() + "-v" + version);


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
This draft PR gives a quick example for implementing [SlimJar](https://github.com/slimjar/slimjar) as a runtime dependency downloader. Currently, only MySQL and SQLite are downloaded; this shrinks the filesize to under 10 megabytes, which should be plenty.

Draft, because there are a couple of big caveats with the plugin:
1) Logging isn't currently available without fiddling with the internal global logger's logging level (feature to supply our own logger coming in the future). On slower systems, this might falsely indicate that the server has crashed (when instead it's still processing the dependencies).
2) SlimJar downloads its own dependencies to the `$HOME` folder; this currently can't be changed (feature coming in next patch). On Pterodactyl this leads to a "?" folder being created to the container root, since Ptero doesn't support folder names beginning with a dot.
3) No documentation available currently.

Closes #1944 when/if next patch ever arrives.