### PR TITLE
Update secret key link for Buycraft

### DIFF
--- a/Plan/common/src/main/resources/assets/plan/bungeeconfig.yml
+++ b/Plan/common/src/main/resources/assets/plan/bungeeconfig.yml
@@ -208,5 +208,5 @@ Export:
 # -----------------------------------------------------
 Plugins:
   Buycraft:
-    # http://help.buycraft.net/article/36-where-to-find-the-secret-key
+    # https://docs.tebex.io/store/faq#how-can-i-find-my-secret-key
     Secret: "-"

--- a/Plan/common/src/main/resources/assets/plan/config.yml
+++ b/Plan/common/src/main/resources/assets/plan/config.yml
@@ -214,7 +214,7 @@ Export:
 # -----------------------------------------------------
 Plugins:
   Buycraft:
-    # http://help.buycraft.net/article/36-where-to-find-the-secret-key
+    # https://docs.tebex.io/store/faq#how-can-i-find-my-secret-key
     Secret: '-'
   Factions:
     HideFactions:


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [ ] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [ ] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
The current buycraft link to find the secret key now goes to a 404 page. This PR updates it to their new tebex.io link, which is the first entry in the FAQ.