### PR TITLE
Notify about old versions of html customized files

### DIFF
--- a/Plan/bukkit/src/main/java/com/djrapitops/plan/modules/bukkit/BukkitTaskModule.java
+++ b/Plan/bukkit/src/main/java/com/djrapitops/plan/modules/bukkit/BukkitTaskModule.java
@@ -18,6 +18,7 @@ package com.djrapitops.plan.modules.bukkit;
 
 import com.djrapitops.plan.TaskSystem;
 import com.djrapitops.plan.delivery.web.ResourceWriteTask;
+import com.djrapitops.plan.delivery.web.WebAssetVersionCheckTask;
 import com.djrapitops.plan.delivery.webserver.cache.JSONFileStorage;
 import com.djrapitops.plan.extension.ExtensionServerDataUpdater;
 import com.djrapitops.plan.gathering.ShutdownDataPreservation;
@@ -88,4 +89,8 @@ public interface BukkitTaskModule {
     @Binds
     @IntoSet
     TaskSystem.Task bindResourceWriteTask(ResourceWriteTask resourceWriteTask);
+
+    @Binds
+    @IntoSet
+    TaskSystem.Task bindWebAssetVersionCheckTask(WebAssetVersionCheckTask webAssetVersionCheckTask);
 }

--- a/Plan/bungeecord/src/main/java/com/djrapitops/plan/modules/bungee/BungeeTaskModule.java
+++ b/Plan/bungeecord/src/main/java/com/djrapitops/plan/modules/bungee/BungeeTaskModule.java
@@ -18,6 +18,7 @@ package com.djrapitops.plan.modules.bungee;
 
 import com.djrapitops.plan.TaskSystem;
 import com.djrapitops.plan.delivery.web.ResourceWriteTask;
+import com.djrapitops.plan.delivery.web.WebAssetVersionCheckTask;
 import com.djrapitops.plan.delivery.webserver.cache.JSONFileStorage;
 import com.djrapitops.plan.extension.ExtensionServerDataUpdater;
 import com.djrapitops.plan.gathering.timed.BungeePingCounter;
@@ -77,4 +78,8 @@ public interface BungeeTaskModule {
     @Binds
     @IntoSet
     TaskSystem.Task bindResourceWriteTask(ResourceWriteTask resourceWriteTask);
+
+    @Binds
+    @IntoSet
+    TaskSystem.Task bindWebAssetVersionCheckTask(WebAssetVersionCheckTask webAssetVersionCheckTask);
 }

--- a/Plan/common/build.gradle
+++ b/Plan/common/build.gradle
@@ -30,19 +30,19 @@ task updateVersion(type: Copy) {
 }
 
 task determineWebAssetModifications {
-    file("build/sources/resources/WebAssetVersion.yml").text = ""
+    file("build/sources/resources/WebAssetVersion.yml").text = "" // Clear previous build
     ConfigurableFileTree tree = fileTree(dir: 'src/main/resources/assets/plan/web')
     tree.forEach { File f ->
-        def buildInfo = new ByteArrayOutputStream()
+        def gitModified = new ByteArrayOutputStream()
         exec {
             commandLine 'git', 'log', '-1', '--pretty=%ct', f.toString()
-            standardOutput = buildInfo
+            standardOutput = gitModified
         }
-        def date = Integer.parseInt(buildInfo.toString().strip())
+        def modified = Integer.parseInt(gitModified.toString().strip())
+        def relativePath = tree.getDir().toPath().relativize(f.toPath()) // File path relative to the tree
         file("build/sources/resources/WebAssetVersion.yml").text += String.format(
-                "%s: %s\n",
-                tree.getDir().toPath().relativize(f.toPath()).toString().replace('.', ','),
-                date
+                // writing YAML as raw text probably isn't the best idea
+                "%s: %s\n", relativePath.toString().replace('.', ','), modified
         )
     }
 }

--- a/Plan/common/build.gradle
+++ b/Plan/common/build.gradle
@@ -28,6 +28,25 @@ task updateVersion(type: Copy) {
     into 'build/sources/resources/'
     filter(ReplaceTokens, tokens: [version: '' + project.ext.fullVersion])
 }
+
+task determineWebAssetModifications {
+    file("build/sources/resources/WebAssetVersion.yml").text = ""
+    ConfigurableFileTree tree = fileTree(dir: 'src/main/resources/assets/plan/web')
+    tree.forEach { File f ->
+        def buildInfo = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'log', '-1', '--pretty=%ct', f.toString()
+            standardOutput = buildInfo
+        }
+        def date = Integer.parseInt(buildInfo.toString().strip())
+        file("build/sources/resources/WebAssetVersion.yml").text += String.format(
+                "%s: %s\n",
+                tree.getDir().toPath().relativize(f.toPath()).toString().replace('.', ','),
+                date
+        )
+    }
+}
+
 processResources {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
     dependsOn updateVersion
@@ -35,6 +54,7 @@ processResources {
 }
 
 shadowJar {
+    dependsOn determineWebAssetModifications
     dependsOn processResources
 
     // Exclude these files

--- a/Plan/common/build.gradle
+++ b/Plan/common/build.gradle
@@ -31,7 +31,7 @@ task updateVersion(type: Copy) {
 
 task determineWebAssetModifications {
     def versionFile = file("build/resources/main/assets/plan/WebAssetVersion.yml")
-    versionFile.mkdirs()
+    versionFile.parentFile.mkdirs()
     versionFile.text = "" // Clear previous build
     ConfigurableFileTree tree = fileTree(dir: 'src/main/resources/assets/plan/web')
     tree.forEach { File f ->

--- a/Plan/common/build.gradle
+++ b/Plan/common/build.gradle
@@ -30,7 +30,8 @@ task updateVersion(type: Copy) {
 }
 
 task determineWebAssetModifications {
-    file("build/sources/resources/WebAssetVersion.yml").text = "" // Clear previous build
+    def versionFile = file("build/resources/main/assets/plan/WebAssetVersion.yml")
+    versionFile.text = "" // Clear previous build
     ConfigurableFileTree tree = fileTree(dir: 'src/main/resources/assets/plan/web')
     tree.forEach { File f ->
         def gitModified = new ByteArrayOutputStream()
@@ -38,10 +39,10 @@ task determineWebAssetModifications {
             commandLine 'git', 'log', '-1', '--pretty=%ct', f.toString()
             standardOutput = gitModified
         }
-        def modified = Integer.parseInt(gitModified.toString().strip())
+        // git returns UNIX time in seconds, but most things in Java use UNIX time in milliseconds
+        def modified = Long.parseLong(gitModified.toString().strip()) * 1000
         def relativePath = tree.getDir().toPath().relativize(f.toPath()) // File path relative to the tree
-        file("build/sources/resources/WebAssetVersion.yml").text += String.format(
-                // writing YAML as raw text probably isn't the best idea
+        versionFile.text += String.format( // writing YAML as raw text probably isn't the best idea
                 "%s: %s\n", relativePath.toString().replace('.', ','), modified
         )
     }

--- a/Plan/common/build.gradle
+++ b/Plan/common/build.gradle
@@ -31,6 +31,7 @@ task updateVersion(type: Copy) {
 
 task determineWebAssetModifications {
     def versionFile = file("build/resources/main/assets/plan/WebAssetVersion.yml")
+    versionFile.mkdirs()
     versionFile.text = "" // Clear previous build
     ConfigurableFileTree tree = fileTree(dir: 'src/main/resources/assets/plan/web')
     tree.forEach { File f ->

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/web/WebAssetVersionCheckTask.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/web/WebAssetVersionCheckTask.java
@@ -109,7 +109,7 @@ public class WebAssetVersionCheckTask extends TaskSystem.Task {
                      resource,
                      resourceFile.get().lastModified(),
                      webAssetVersion.get()
-                 )));
+                 ));
              }
          }
          return Optional.empty();

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/web/WebAssetVersionCheckTask.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/web/WebAssetVersionCheckTask.java
@@ -1,0 +1,128 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.delivery.web;
+
+import com.djrapitops.plan.TaskSystem;
+import com.djrapitops.plan.delivery.formatting.Formatters;
+import com.djrapitops.plan.settings.config.ConfigNode;
+import com.djrapitops.plan.settings.config.PlanConfig;
+import com.djrapitops.plan.storage.file.PlanFiles;
+import net.playeranalytics.plugin.scheduling.RunnableFactory;
+import net.playeranalytics.plugin.server.PluginLogger;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Task in charge of checking html customized files on enable to see if they are outdated.
+ */
+@Singleton
+public class WebAssetVersionCheckTask extends TaskSystem.Task {
+
+    private final PlanConfig config;
+    private final PlanFiles files;
+    private final PluginLogger logger;
+    private final WebAssetVersions webAssetVersions;
+    private final Formatters formatters;
+
+    @Inject
+    public WebAssetVersionCheckTask(
+            PlanConfig config,
+            PlanFiles files,
+            PluginLogger logger,
+            WebAssetVersions webAssetVersions,
+            Formatters formatters
+    ) {
+        this.config = config;
+        this.files = files;
+        this.logger = logger;
+        this.webAssetVersions = webAssetVersions;
+        this.formatters = formatters;
+    }
+
+    @Override
+    public void register(RunnableFactory runnableFactory) {
+        runnableFactory.create(this).runTaskLaterAsynchronously(3, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void run() {
+        Optional<ConfigNode> planCustomizationNode = getPlanCustomizationNode();
+        if (planCustomizationNode.isPresent()) {
+            try {
+                webAssetVersions.prepare();
+            } catch (IOException e) {
+                logger.warn("Could not read web asset versions, ", e);
+                logger.warn("Web asset version check will be skipped!");
+                return;
+            }
+
+            List<AssetInfo> outdated = new ArrayList<>();
+
+            for (ConfigNode child : planCustomizationNode.get().getChildren()) {
+                if (child.getBoolean()) {
+                    String resource = child.getKey(false).replace(',', '.');
+                    Optional<File> resourceFile = files.attemptToFind(resource);
+                    Optional<Long> webAssetVersion = webAssetVersions.getWebAssetVersion(resource);
+                    if (resourceFile.isPresent() && webAssetVersion.isPresent()) {
+                        if (webAssetVersion.get() > resourceFile.get().lastModified()) {
+                            outdated.add(new AssetInfo(
+                                resource,
+                                resourceFile.get().lastModified(),
+                                webAssetVersion.get()
+                            ));
+                        }
+                    }
+                }
+            }
+
+            if (!outdated.isEmpty()) {
+                logger.warn("You have customized files which are out of date due to recent updates!");
+                logger.warn("Plan may not work properly until these files are updated to include the new modifications.");
+            }
+            for (AssetInfo asset : outdated) {
+                logger.warn(String.format("- %s was modified %s, but the plugin contains a version from %s",
+                    asset.filename,
+                    formatters.secondLong().apply(asset.modifiedAt),
+                    formatters.secondLong().apply(asset.expectedModifiedAt)
+                ));
+            }
+        }
+    }
+
+    private Optional<ConfigNode> getPlanCustomizationNode() {
+        return config.getResourceSettings().getCustomizationConfigNode().getNode("Plan");
+    }
+
+    private static class AssetInfo {
+        public String filename;
+        public long modifiedAt;
+        public long expectedModifiedAt;
+
+        public AssetInfo(String filename, long modifiedAt, long expectedModifiedAt) {
+            this.filename = filename;
+            this.modifiedAt = modifiedAt;
+            this.expectedModifiedAt = expectedModifiedAt;
+        }
+    }
+}

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/web/WebAssetVersionCheckTask.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/web/WebAssetVersionCheckTask.java
@@ -105,7 +105,7 @@ public class WebAssetVersionCheckTask extends TaskSystem.Task {
          Optional<Long> webAssetVersion = webAssetVersions.getWebAssetVersion(resource);
          if (resourceFile.isPresent() && webAssetVersion.isPresent()) {
              if (webAssetVersion.get() > resourceFile.get().lastModified()) {
-                 return new Optional.of(new AssetInfo(
+                 return Optional.of(new AssetInfo(
                      resource,
                      resourceFile.get().lastModified(),
                      webAssetVersion.get()

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/web/WebAssetVersionCheckTask.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/web/WebAssetVersionCheckTask.java
@@ -82,17 +82,7 @@ public class WebAssetVersionCheckTask extends TaskSystem.Task {
             for (ConfigNode child : planCustomizationNode.get().getChildren()) {
                 if (child.getBoolean()) {
                     String resource = child.getKey(false).replace(',', '.');
-                    Optional<File> resourceFile = files.attemptToFind(resource);
-                    Optional<Long> webAssetVersion = webAssetVersions.getWebAssetVersion(resource);
-                    if (resourceFile.isPresent() && webAssetVersion.isPresent()) {
-                        if (webAssetVersion.get() > resourceFile.get().lastModified()) {
-                            outdated.add(new AssetInfo(
-                                resource,
-                                resourceFile.get().lastModified(),
-                                webAssetVersion.get()
-                            ));
-                        }
-                    }
+                    findOutdatedResource(resource).ifPresent(outdated::add);
                 }
             }
 
@@ -108,6 +98,21 @@ public class WebAssetVersionCheckTask extends TaskSystem.Task {
                 ));
             }
         }
+    }
+
+    private Optional<AssetInfo> findOutdatedResource(String resource) {
+         Optional<File> resourceFile = files.attemptToFind(resource);
+         Optional<Long> webAssetVersion = webAssetVersions.getWebAssetVersion(resource);
+         if (resourceFile.isPresent() && webAssetVersion.isPresent()) {
+             if (webAssetVersion.get() > resourceFile.get().lastModified()) {
+                 return new Optional.of(new AssetInfo(
+                     resource,
+                     resourceFile.get().lastModified(),
+                     webAssetVersion.get()
+                 )));
+             }
+         }
+         return Optional.empty();
     }
 
     private Optional<ConfigNode> getPlanCustomizationNode() {

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/web/WebAssetVersions.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/web/WebAssetVersions.java
@@ -1,0 +1,55 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.delivery.web;
+
+import com.djrapitops.plan.settings.config.Config;
+import com.djrapitops.plan.settings.config.ConfigNode;
+import com.djrapitops.plan.settings.config.ConfigReader;
+import com.djrapitops.plan.storage.file.PlanFiles;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.Optional;
+
+@Singleton
+public class WebAssetVersions {
+
+  private final PlanFiles files;
+  private Config webAssetConfig;
+
+  private boolean prepared;
+
+  @Inject
+  public WebAssetVersions(
+      PlanFiles files
+  ) {
+    this.files = files;
+  }
+
+  public void prepare() throws IOException {
+    try (ConfigReader reader = new ConfigReader(files.getResourceFromJar("WebAssetVersion.yml").asInputStream())) {
+      webAssetConfig = reader.read();
+    }
+  }
+
+  public Optional<Long> getWebAssetVersion(String resource) {
+    if (webAssetConfig == null) return Optional.empty();
+
+    return webAssetConfig.getNode(resource.replace('.', ',')).map(ConfigNode::getLong);
+  }
+}

--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/file/PlanFiles.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/file/PlanFiles.java
@@ -137,7 +137,7 @@ public class PlanFiles implements SubSystem {
         ));
     }
 
-    private Optional<File> attemptToFind(String resourceName) {
+    public Optional<File> attemptToFind(String resourceName) {
         Path dir = getCustomizationDirectory();
         if (dir.toFile().exists() && dir.toFile().isDirectory()) {
             Path asPath = dir.resolve(resourceName);

--- a/Plan/nukkit/src/main/java/com/djrapitops/plan/modules/nukkit/NukkitTaskModule.java
+++ b/Plan/nukkit/src/main/java/com/djrapitops/plan/modules/nukkit/NukkitTaskModule.java
@@ -19,6 +19,7 @@ package com.djrapitops.plan.modules.nukkit;
 import cn.nukkit.level.Level;
 import com.djrapitops.plan.TaskSystem;
 import com.djrapitops.plan.delivery.web.ResourceWriteTask;
+import com.djrapitops.plan.delivery.web.WebAssetVersionCheckTask;
 import com.djrapitops.plan.delivery.webserver.cache.JSONFileStorage;
 import com.djrapitops.plan.extension.ExtensionServerDataUpdater;
 import com.djrapitops.plan.gathering.ShutdownDataPreservation;
@@ -88,4 +89,8 @@ public interface NukkitTaskModule {
     @Binds
     @IntoSet
     TaskSystem.Task bindResourceWriteTask(ResourceWriteTask resourceWriteTask);
+
+    @Binds
+    @IntoSet
+    TaskSystem.Task bindWebAssetVersionCheckTask(WebAssetVersionCheckTask webAssetVersionCheckTask);
 }

--- a/Plan/sponge/src/main/java/com/djrapitops/plan/modules/sponge/SpongeTaskModule.java
+++ b/Plan/sponge/src/main/java/com/djrapitops/plan/modules/sponge/SpongeTaskModule.java
@@ -18,6 +18,7 @@ package com.djrapitops.plan.modules.sponge;
 
 import com.djrapitops.plan.TaskSystem;
 import com.djrapitops.plan.delivery.web.ResourceWriteTask;
+import com.djrapitops.plan.delivery.web.WebAssetVersionCheckTask;
 import com.djrapitops.plan.delivery.webserver.cache.JSONFileStorage;
 import com.djrapitops.plan.extension.ExtensionServerDataUpdater;
 import com.djrapitops.plan.gathering.ShutdownDataPreservation;
@@ -88,4 +89,8 @@ public interface SpongeTaskModule {
     @Binds
     @IntoSet
     TaskSystem.Task bindResourceWriteTask(ResourceWriteTask resourceWriteTask);
+
+    @Binds
+    @IntoSet
+    TaskSystem.Task bindWebAssetVersionCheckTask(WebAssetVersionCheckTask webAssetVersionCheckTask);
 }

--- a/Plan/velocity/src/main/java/com/djrapitops/plan/modules/velocity/VelocityTaskModule.java
+++ b/Plan/velocity/src/main/java/com/djrapitops/plan/modules/velocity/VelocityTaskModule.java
@@ -18,6 +18,7 @@ package com.djrapitops.plan.modules.velocity;
 
 import com.djrapitops.plan.TaskSystem;
 import com.djrapitops.plan.delivery.web.ResourceWriteTask;
+import com.djrapitops.plan.delivery.web.WebAssetVersionCheckTask;
 import com.djrapitops.plan.delivery.webserver.cache.JSONFileStorage;
 import com.djrapitops.plan.extension.ExtensionServerDataUpdater;
 import com.djrapitops.plan.gathering.timed.ProxyTPSCounter;
@@ -77,4 +78,8 @@ public interface VelocityTaskModule {
     @Binds
     @IntoSet
     TaskSystem.Task bindResourceWriteTask(ResourceWriteTask resourceWriteTask);
+
+    @Binds
+    @IntoSet
+    TaskSystem.Task bindWebAssetVersionCheckTask(WebAssetVersionCheckTask webAssetVersionCheckTask);
 }


### PR DESCRIPTION
Closes #1995.

I am unsure if anything should be done differently, most notably [the actual warning part](https://github.com/rymiel/Plan/blob/67384e88a141811c4d318745cda35c9b2ca97aad/Plan/common/src/main/java/com/djrapitops/plan/delivery/web/WebAssetVersionCheckTask.java#L99-L108), like if it needs any special locale things, but the logic should mostly be there. When the [task itself is run](https://github.com/rymiel/Plan/blob/67384e88a141811c4d318745cda35c9b2ca97aad/Plan/common/src/main/java/com/djrapitops/plan/delivery/web/WebAssetVersionCheckTask.java#L65) could also probably be changed.
~~(and also i haven't tested it much)~~
