### PR TITLE
Lower MySQL leak detection threshold

### DIFF
--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/database/MySQLDB.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/database/MySQLDB.java
@@ -121,7 +121,7 @@ public class MySQLDB extends SQLDB {
                 hikariConfig.setMaximumPoolSize(1);
             }
             hikariConfig.setMaxLifetime(TimeUnit.MINUTES.toMillis(25L));
-            hikariConfig.setLeakDetectionThreshold(TimeUnit.MINUTES.toMillis(10L));
+            hikariConfig.setLeakDetectionThreshold(TimeUnit.SECONDS.toMillis(29L));
 
             this.dataSource = new HikariDataSource(hikariConfig);
         } catch (HikariPool.PoolInitializationException e) {


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
HikariCP's connectionTimeout defaults to 30 seconds, so at 10 minutes the connection leak detector will never trigger. Setting the threshold to 29 seconds makes the leak detector actually work.