### PR TITLE
Added ViaVersion as an optional dependency on Velocity

### DIFF
--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
@@ -56,6 +56,7 @@ public class Contributors {
             new Contributor("Malachiel", LANG),
             new Contributor("Miclebrick", CODE),
             new Contributor("Morsmorse", LANG),
+            new Contributor("MAXOUXAX", CODE),
             new Contributor("Nogapra", LANG),
             new Contributor("Sander0542", LANG),
             new Contributor("Saph1s", LANG),

--- a/Plan/velocity/src/main/java/com/djrapitops/plan/PlanVelocity.java
+++ b/Plan/velocity/src/main/java/com/djrapitops/plan/PlanVelocity.java
@@ -27,6 +27,7 @@ import com.velocitypowered.api.command.CommandManager;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
+import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
@@ -54,6 +55,9 @@ import java.util.logging.Level;
         name = "Plan",
         version = "@version@",
         description = "Player Analytics Plugin by AuroraLS3",
+        dependencies = {
+                @Dependency(id = "viaversion", optional = true)
+        },
         authors = {"AuroraLS3"}
 )
 public class PlanVelocity implements PlanPlugin {


### PR DESCRIPTION
### Description
Added ViaVersion as an optional dependency on Velocity to allow the ViaVersion extension to correctly get ViaVersion API.
That fixes an issue where an error is thrown at startup saying that ViaVersion has not loaded the platform yet.