### PR TITLE
Fix Curseforge upload action

### DIFF
--- a/.github/workflows/curseforge-upload.yml
+++ b/.github/workflows/curseforge-upload.yml
@@ -2,7 +2,7 @@ name: Upload artifact to CurseForge
 
 on:
   release:
-    types: [ released, prereleased ]
+    types: [ published ]
 
 jobs:
   upload_release:


### PR DESCRIPTION
Apparently `types: prerelease` doesn't trigger when a draft release is published as a prerelease.