### PR TITLE
Properly use a component serializer for VelocityCMDSender

### DIFF
--- a/Plan/velocity/src/main/java/com/djrapitops/plan/commands/use/VelocityCMDSender.java
+++ b/Plan/velocity/src/main/java/com/djrapitops/plan/commands/use/VelocityCMDSender.java
@@ -17,7 +17,6 @@
 package com.djrapitops.plan.commands.use;
 
 import com.velocitypowered.api.command.CommandSource;
-import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 import java.util.Objects;

--- a/Plan/velocity/src/main/java/com/djrapitops/plan/commands/use/VelocityCMDSender.java
+++ b/Plan/velocity/src/main/java/com/djrapitops/plan/commands/use/VelocityCMDSender.java
@@ -18,6 +18,7 @@ package com.djrapitops.plan.commands.use;
 
 import com.velocitypowered.api.command.CommandSource;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -53,7 +54,7 @@ public class VelocityCMDSender implements CMDSender {
 
     @Override
     public void send(String message) {
-        commandSource.sendMessage(Component.text(message));
+        commandSource.sendMessage(LegacyComponentSerializer.legacySection().deserialize(message));
     }
 
     @Override


### PR DESCRIPTION
### Description
The current system depends on mojang maintaining section signs for formatting which may be dropped any moment, a LegacyComponentSerializer turns the section-sign syntax into a proper Component
