### PR TITLE
Fix for removing the wrong driver from the DriverManager

### DIFF
--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/database/MySQLDB.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/database/MySQLDB.java
@@ -153,7 +153,9 @@ public class MySQLDB extends SQLDB {
         Enumeration<Driver> drivers = DriverManager.getDrivers();
         while (drivers.hasMoreElements()) {
             Driver driver = drivers.nextElement();
-            if ("com.mysql.cj.jdbc.Driver".equals(driver.getClass().getName())) {
+            Class<?> driverClass = driver.getClass();
+            // Checks that it's from our class loader to avoid unloading another plugin's/the server's driver
+            if ("com.mysql.cj.jdbc.Driver".equals(driverClass.getName()) && driverClass.getClassLoader() == driverClassLoader) {
                 try {
                     DriverManager.deregisterDriver(driver);
                 } catch (SQLException e) {


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
I was able to make a make a test environment to test this, 
- Have MySQL enabled on Plan
- Have a server that is using `com.mysql.cj.jdbc.Driver`, and without `com.mysql.jdbc.Driver` (eg. Paper 1.16.5+)
  + Paper <1.16.5 and Spigot end up working as they (only) include the old driver
- Have a plugin trying to use mysql through the DriverManager, after Plan enables (and unregisters the new driver)

I was able to test that this fix worked in such a environment.

Fixes https://github.com/plan-player-analytics/Plan/issues/2147.

Sorry about the trouble this caused