### PR TITLE
add Votifier to Plugin.yml

### DIFF
--- a/Plan/common/src/main/resources/plugin.yml
+++ b/Plan/common/src/main/resources/plugin.yml
@@ -39,6 +39,7 @@ softdepend:
   - Towny
   - Vault
   - ViaVersion
+  - Votifier
 
 commands:
   plan:


### PR DESCRIPTION
add Votifier to Plugin.yml to stop error:
`[Plan] Loaded class com.vexsoftware.votifier.model.Vote from Votifier v2.7.3 which is not a depend, softdepend or loadbefore of this plugin.`

I haven't edited controbutors as this is such a minor change