### PR TITLE
Added AuthMe to softdepend to disable a warning in Bukkit

### DIFF
--- a/Plan/common/src/main/resources/plugin.yml
+++ b/Plan/common/src/main/resources/plugin.yml
@@ -8,6 +8,7 @@ softdepend:
   - ASkyBlock
   - AdvancedAchievements
   - AdvancedBan
+  - AuthMe
   - BanManager
   - BentoBox
   - CoreProtect


### PR DESCRIPTION
When the Bukkit plugin is used on a server that also has AuthMe installed, a warning message is logged by the plugin manager. The warning correctly explains that although Plan references AuthMe at runtime, it is not a declared `depend`, `softdepend` or `loadbefore` type dependency.

The message is `[14:01:27] [Server thread/WARN]: [Plan] Loaded class fr.xephi.authme.api.v3.AuthMeApi from AuthMe v5.6.0-beta2-b2453 which is not a depend, softdepend or loadbefore of this plugin.`