### PR TITLE
Add comment about users that have pterodactyl

### DIFF
--- a/Plan/common/src/main/java/com/djrapitops/plan/exceptions/database/DBOpException.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/exceptions/database/DBOpException.java
@@ -112,7 +112,7 @@ public class DBOpException extends IllegalStateException implements ExceptionWit
                 break;
             case 13:
                 context.related("Disk or temporary directory is full.")
-                        .whatToDo("Disk or temporary directory is full, attempt to clear space in the temporary directory. See https://sqlite.org/rescode.html#full");
+                        .whatToDo("Disk or temporary directory is full, attempt to clear space in the temporary directory. See https://sqlite.org/rescode.html#full. If you use the Pterodactyl panel, increase the \"tmpfs_size\" config setting. See https://pterodactyl.io/wings/1.0/configuration.html#other-values");
                 break;
             case 1104:
                 context.whatToDo("MySQL has too small query limits for the query. SET SQL_BIG_SELECTS=1 or SET MAX_JOIN_SIZE=# (higher number)");


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [X] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [X] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
Adds a comment telling pterodactyl users what to do. I tested this with a large Plan database and increasing the default 100mb tmp size to 1024mb completely fixed any errors and Plan updated much quicker as you'd expect.
