### PR TITLE
Cleanup ExtensionData code duplication, make adding new extension data provider types easier

### DIFF
--- a/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/ExtensionMethods.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/ExtensionMethods.java
@@ -16,97 +16,27 @@
  */
 package com.djrapitops.plan.extension.extractor;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import com.djrapitops.plan.extension.extractor.dataprovider.AnnotationDataProvider;
+
+import java.util.*;
 
 /**
  * Implementation detail, abstracts away method type reflection to a more usable API.
  */
 public class ExtensionMethods {
 
-    private final List<ExtensionMethod> booleanProviders;
-    private final List<ExtensionMethod> numberProviders;
-    private final List<ExtensionMethod> doubleProviders;
-    private final List<ExtensionMethod> percentageProviders;
-    private final List<ExtensionMethod> stringProviders;
-    private final List<ExtensionMethod> tableProviders;
-    private final List<ExtensionMethod> groupProviders;
-    private final List<ExtensionMethod> dataBuilderProviders;
+    private final List<AnnotationDataProvider<?, ?, ?>> providers;
 
     public ExtensionMethods() {
-        booleanProviders = new ArrayList<>();
-        numberProviders = new ArrayList<>();
-        doubleProviders = new ArrayList<>();
-        percentageProviders = new ArrayList<>();
-        stringProviders = new ArrayList<>();
-        tableProviders = new ArrayList<>();
-        groupProviders = new ArrayList<>();
-        dataBuilderProviders = new ArrayList<>();
+        providers = new ArrayList<>();
     }
 
-    public List<ExtensionMethod> getBooleanProviders() {
-        return booleanProviders;
+    public List<AnnotationDataProvider<?, ?, ?>> getProviders() {
+        return providers;
     }
 
-    public List<ExtensionMethod> getNumberProviders() {
-        return numberProviders;
-    }
-
-    public List<ExtensionMethod> getDoubleProviders() {
-        return doubleProviders;
-    }
-
-    public List<ExtensionMethod> getPercentageProviders() {
-        return percentageProviders;
-    }
-
-    public List<ExtensionMethod> getStringProviders() {
-        return stringProviders;
-    }
-
-    public List<ExtensionMethod> getTableProviders() {
-        return tableProviders;
-    }
-
-    public List<ExtensionMethod> getGroupProviders() {
-        return groupProviders;
-    }
-
-    public List<ExtensionMethod> getDataBuilderProviders() {
-        return dataBuilderProviders;
-    }
-
-    public void addBooleanMethod(ExtensionMethod method) {
-        booleanProviders.add(method);
-    }
-
-    public void addNumberMethod(ExtensionMethod method) {
-        numberProviders.add(method);
-    }
-
-    public void addDoubleMethod(ExtensionMethod method) {
-        doubleProviders.add(method);
-    }
-
-    public void addPercentageMethod(ExtensionMethod method) {
-        percentageProviders.add(method);
-    }
-
-    public void addStringMethod(ExtensionMethod method) {
-        stringProviders.add(method);
-    }
-
-    public void addTableMethod(ExtensionMethod method) {
-        tableProviders.add(method);
-    }
-
-    public void addGroupMethod(ExtensionMethod method) {
-        groupProviders.add(method);
-    }
-
-    public void addDataBuilderMethod(ExtensionMethod method) {
-        dataBuilderProviders.add(method);
+    public void addProvider(AnnotationDataProvider<?, ?, ?> extractor) {
+        providers.add(extractor);
     }
 
     @Override
@@ -114,43 +44,22 @@ public class ExtensionMethods {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExtensionMethods that = (ExtensionMethods) o;
-        return Objects.equals(booleanProviders, that.booleanProviders)
-                && Objects.equals(numberProviders, that.numberProviders)
-                && Objects.equals(doubleProviders, that.doubleProviders)
-                && Objects.equals(percentageProviders, that.percentageProviders)
-                && Objects.equals(stringProviders, that.stringProviders)
-                && Objects.equals(tableProviders, that.tableProviders)
-                && Objects.equals(groupProviders, that.groupProviders)
-                && Objects.equals(dataBuilderProviders, that.dataBuilderProviders);
+        return Objects.equals(providers, that.providers);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(booleanProviders, numberProviders, doubleProviders, percentageProviders, stringProviders, tableProviders, groupProviders, dataBuilderProviders);
+        return Objects.hash(providers);
     }
 
     @Override
     public String toString() {
         return "ExtensionMethods{" +
-                "booleanProviders=" + booleanProviders +
-                ", numberProviders=" + numberProviders +
-                ", doubleProviders=" + doubleProviders +
-                ", percentageProviders=" + percentageProviders +
-                ", stringProviders=" + stringProviders +
-                ", tableProviders=" + tableProviders +
-                ", groupProviders=" + groupProviders +
-                ", dataBuilderProviders=" + dataBuilderProviders +
+                "providers=" + providers +
                 '}';
     }
 
     public boolean isEmpty() {
-        return booleanProviders.isEmpty()
-                && numberProviders.isEmpty()
-                && doubleProviders.isEmpty()
-                && percentageProviders.isEmpty()
-                && stringProviders.isEmpty()
-                && tableProviders.isEmpty()
-                && groupProviders.isEmpty()
-                && dataBuilderProviders.isEmpty();
+        return providers.isEmpty();
     }
 }

--- a/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/AnnotationDataProvider.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/AnnotationDataProvider.java
@@ -1,0 +1,90 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.extension.extractor.dataprovider;
+
+import com.djrapitops.plan.extension.annotation.Conditional;
+import com.djrapitops.plan.extension.annotation.Tab;
+import com.djrapitops.plan.extension.builder.DataValue;
+import com.djrapitops.plan.extension.builder.ExtensionDataBuilder;
+import com.djrapitops.plan.extension.builder.ValueBuilder;
+import com.djrapitops.plan.extension.extractor.ExtensionMethod;
+
+import java.lang.annotation.Annotation;
+import java.util.function.Supplier;
+
+/**
+ * A helper class for accessing data from a Provider annotation, as well as storing the {@link ExtensionMethod}.
+ * @param <A> the annotation type
+ * @param <R> the return type (to check if the return type is correct)
+ * @param <D> the data type
+ */
+public abstract class AnnotationDataProvider<A extends Annotation, R, D> {
+
+    protected final A provider;
+    protected final ExtensionMethod method;
+    protected final Class<R> returnType;
+    protected final Class<D> dataType;
+
+    public AnnotationDataProvider(A provider, ExtensionMethod method, Class<R> returnType, Class<D> dataType) {
+        this.provider = provider;
+        this.method = method;
+        this.returnType = returnType;
+        this.dataType = dataType;
+    }
+
+    public final A getProvider() {
+        return provider;
+    }
+
+    public final ExtensionMethod getExtensionMethod() {
+        return method;
+    }
+
+    public final Class<R> getReturnType() {
+        return returnType;
+    }
+
+    public final Class<D> getDataType() {
+        return dataType;
+    }
+
+    public String getBuilderName() {
+        return method.getMethodName();
+    }
+
+    public ValueBuilder getValueBuilder(ExtensionDataBuilder dataBuilder) {
+        return dataBuilder.valueBuilder(getBuilderName())
+                .methodName(method)
+                .conditional(method.getAnnotationOrNull(Conditional.class))
+                .showOnTab(method.getAnnotationOrNull(Tab.class));
+    }
+
+    public abstract DataValue<D> addDataValueToBuilder(ValueBuilder builder, Supplier<D> dataSupplier);
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof AnnotationDataProvider)) {
+            return false;
+        }
+        AnnotationDataProvider<?, ?, ?> other = (AnnotationDataProvider<?, ?, ?>) obj;
+        return super.equals(obj)
+                && provider == other.provider
+                && method == other.method
+                && returnType == other.returnType
+                && dataType == other.dataType;
+    }
+}

--- a/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/AnnotationFullDataProvider.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/AnnotationFullDataProvider.java
@@ -1,0 +1,47 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.extension.extractor.dataprovider;
+
+import com.djrapitops.plan.extension.builder.ExtensionDataBuilder;
+import com.djrapitops.plan.extension.builder.ValueBuilder;
+import com.djrapitops.plan.extension.extractor.ExtensionMethod;
+
+import java.lang.annotation.Annotation;
+
+public abstract class AnnotationFullDataProvider<A extends Annotation, R, D> extends AnnotationTextAndIconProvider<A, R, D> {
+
+    public AnnotationFullDataProvider(A provider, ExtensionMethod method, Class<R> returnType, Class<D> dataType) {
+        super(provider, method, returnType, dataType);
+    }
+
+    @Override
+    public String getBuilderName() {
+        return text();
+    }
+
+    @Override
+    public ValueBuilder getValueBuilder(ExtensionDataBuilder dataBuilder) {
+        return super.getValueBuilder(dataBuilder)
+                .description(description())
+                .priority(priority())
+                .showInPlayerTable(showInPlayerTable());
+    }
+
+    public abstract String description();
+    public abstract int priority();
+    public abstract boolean showInPlayerTable();
+}

--- a/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/AnnotationTextAndIconProvider.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/AnnotationTextAndIconProvider.java
@@ -1,0 +1,43 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.extension.extractor.dataprovider;
+
+import com.djrapitops.plan.extension.builder.ExtensionDataBuilder;
+import com.djrapitops.plan.extension.builder.ValueBuilder;
+import com.djrapitops.plan.extension.extractor.ExtensionMethod;
+import com.djrapitops.plan.extension.icon.Color;
+import com.djrapitops.plan.extension.icon.Family;
+
+import java.lang.annotation.Annotation;
+
+public abstract class AnnotationTextAndIconProvider<A extends Annotation, R, D> extends AnnotationDataProvider<A, R, D> {
+
+    public AnnotationTextAndIconProvider(A provider, ExtensionMethod method, Class<R> returnType, Class<D> dataType) {
+        super(provider, method, returnType, dataType);
+    }
+
+    @Override
+    public ValueBuilder getValueBuilder(ExtensionDataBuilder dataBuilder) {
+        return super.getValueBuilder(dataBuilder)
+                .icon(iconName(), iconFamily(), iconColor());
+    }
+
+    public abstract String text();
+    public abstract String iconName();
+    public abstract Family iconFamily();
+    public abstract Color iconColor();
+}

--- a/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/BooleanDataProvider.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/BooleanDataProvider.java
@@ -1,0 +1,80 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.extension.extractor.dataprovider;
+
+import com.djrapitops.plan.extension.annotation.BooleanProvider;
+import com.djrapitops.plan.extension.builder.DataValue;
+import com.djrapitops.plan.extension.builder.ExtensionDataBuilder;
+import com.djrapitops.plan.extension.builder.ValueBuilder;
+import com.djrapitops.plan.extension.extractor.ExtensionMethod;
+import com.djrapitops.plan.extension.icon.Color;
+import com.djrapitops.plan.extension.icon.Family;
+
+import java.util.function.Supplier;
+
+public class BooleanDataProvider extends AnnotationFullDataProvider<BooleanProvider, Boolean, Boolean> {
+
+    public BooleanDataProvider(BooleanProvider provider, ExtensionMethod method) {
+        super(provider, method, boolean.class, Boolean.class);
+    }
+
+    @Override
+    public ValueBuilder getValueBuilder(ExtensionDataBuilder dataBuilder) {
+        return super.getValueBuilder(dataBuilder)
+                .hideFromUsers(provider);
+    }
+
+    @Override
+    public DataValue<Boolean> addDataValueToBuilder(ValueBuilder builder, Supplier<Boolean> dataSupplier) {
+        return builder.buildBooleanProvidingCondition(dataSupplier, provider.conditionName());
+    }
+
+    @Override
+    public String iconName() {
+        return provider.iconName();
+    }
+
+    @Override
+    public Family iconFamily() {
+        return provider.iconFamily();
+    }
+
+    @Override
+    public Color iconColor() {
+        return provider.iconColor();
+    }
+
+    @Override
+    public String text() {
+        return provider.text();
+    }
+
+    @Override
+    public String description() {
+        return provider.description();
+    }
+
+    @Override
+    public int priority() {
+        return provider.priority();
+    }
+
+    @Override
+    public boolean showInPlayerTable() {
+        return provider.showInPlayerTable();
+    }
+}

--- a/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/DataBuilderDataProvider.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/DataBuilderDataProvider.java
@@ -1,0 +1,37 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.extension.extractor.dataprovider;
+
+import com.djrapitops.plan.extension.annotation.DataBuilderProvider;
+import com.djrapitops.plan.extension.builder.DataValue;
+import com.djrapitops.plan.extension.builder.ExtensionDataBuilder;
+import com.djrapitops.plan.extension.builder.ValueBuilder;
+import com.djrapitops.plan.extension.extractor.ExtensionMethod;
+
+import java.util.function.Supplier;
+
+public class DataBuilderDataProvider extends AnnotationDataProvider<DataBuilderProvider, ExtensionDataBuilder, ExtensionDataBuilder> {
+
+    public DataBuilderDataProvider(DataBuilderProvider provider, ExtensionMethod method) {
+        super(provider, method, ExtensionDataBuilder.class, null);
+    }
+
+    @Override
+    public DataValue<ExtensionDataBuilder> addDataValueToBuilder(ValueBuilder builder, Supplier<ExtensionDataBuilder> dataSupplier) {
+        throw new IllegalStateException("addDataValueToBuilder is not suppose to be called on DataBuilderDataProvider");
+    }
+}

--- a/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/DoubleDataProvider.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/DoubleDataProvider.java
@@ -1,0 +1,73 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.extension.extractor.dataprovider;
+
+import com.djrapitops.plan.extension.annotation.DoubleProvider;
+import com.djrapitops.plan.extension.builder.DataValue;
+import com.djrapitops.plan.extension.builder.ValueBuilder;
+import com.djrapitops.plan.extension.extractor.ExtensionMethod;
+import com.djrapitops.plan.extension.icon.Color;
+import com.djrapitops.plan.extension.icon.Family;
+
+import java.util.function.Supplier;
+
+public class DoubleDataProvider extends AnnotationFullDataProvider<DoubleProvider, Double, Double> {
+
+    public DoubleDataProvider(DoubleProvider provider, ExtensionMethod method) {
+        super(provider, method, double.class, Double.class);
+    }
+
+    @Override
+    public String iconName() {
+        return provider.iconName();
+    }
+
+    @Override
+    public Family iconFamily() {
+        return provider.iconFamily();
+    }
+
+    @Override
+    public Color iconColor() {
+        return provider.iconColor();
+    }
+
+    @Override
+    public String text() {
+        return provider.text();
+    }
+
+    @Override
+    public String description() {
+        return provider.description();
+    }
+
+    @Override
+    public int priority() {
+        return provider.priority();
+    }
+
+    @Override
+    public boolean showInPlayerTable() {
+        return provider.showInPlayerTable();
+    }
+
+    @Override
+    public DataValue<Double> addDataValueToBuilder(ValueBuilder builder, Supplier<Double> dataSupplier) {
+        return builder.buildDouble(dataSupplier);
+    }
+}

--- a/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/GroupDataProvider.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/GroupDataProvider.java
@@ -1,0 +1,63 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.extension.extractor.dataprovider;
+
+import com.djrapitops.plan.extension.annotation.GroupProvider;
+import com.djrapitops.plan.extension.builder.DataValue;
+import com.djrapitops.plan.extension.builder.ValueBuilder;
+import com.djrapitops.plan.extension.extractor.ExtensionMethod;
+import com.djrapitops.plan.extension.icon.Color;
+import com.djrapitops.plan.extension.icon.Family;
+
+import java.util.function.Supplier;
+
+public class GroupDataProvider extends AnnotationTextAndIconProvider<GroupProvider, String[], String[]> {
+
+    public GroupDataProvider(GroupProvider provider, ExtensionMethod method) {
+        super(provider, method, String[].class, String[].class);
+    }
+
+    @Override
+    public String getBuilderName() {
+        return text();
+    }
+
+    @Override
+    public DataValue<String[]> addDataValueToBuilder(ValueBuilder builder, Supplier<String[]> dataSupplier) {
+        return builder.buildGroup(dataSupplier);
+    }
+
+    @Override
+    public String text() {
+        return provider.text();
+    }
+
+    @Override
+    public String iconName() {
+        return provider.iconName();
+    }
+
+    @Override
+    public Family iconFamily() {
+        return provider.iconFamily();
+    }
+
+    @Override
+    public Color iconColor() {
+        return Color.NONE;
+    }
+}

--- a/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/NumberDataProvider.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/NumberDataProvider.java
@@ -1,0 +1,80 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.extension.extractor.dataprovider;
+
+import com.djrapitops.plan.extension.annotation.NumberProvider;
+import com.djrapitops.plan.extension.builder.DataValue;
+import com.djrapitops.plan.extension.builder.ExtensionDataBuilder;
+import com.djrapitops.plan.extension.builder.ValueBuilder;
+import com.djrapitops.plan.extension.extractor.ExtensionMethod;
+import com.djrapitops.plan.extension.icon.Color;
+import com.djrapitops.plan.extension.icon.Family;
+
+import java.util.function.Supplier;
+
+public class NumberDataProvider extends AnnotationFullDataProvider<NumberProvider, Long, Long> {
+
+    public NumberDataProvider(NumberProvider provider, ExtensionMethod method) {
+        super(provider, method, long.class, Long.class);
+    }
+
+    @Override
+    public ValueBuilder getValueBuilder(ExtensionDataBuilder dataBuilder) {
+        return super.getValueBuilder(dataBuilder)
+                .format(provider.format());
+    }
+
+    @Override
+    public DataValue<Long> addDataValueToBuilder(ValueBuilder builder, Supplier<Long> dataSupplier) {
+        return builder.buildNumber(dataSupplier);
+    }
+
+    @Override
+    public String iconName() {
+        return provider.iconName();
+    }
+
+    @Override
+    public Family iconFamily() {
+        return provider.iconFamily();
+    }
+
+    @Override
+    public Color iconColor() {
+        return provider.iconColor();
+    }
+
+    @Override
+    public String text() {
+        return provider.text();
+    }
+
+    @Override
+    public String description() {
+        return provider.description();
+    }
+
+    @Override
+    public int priority() {
+        return provider.priority();
+    }
+
+    @Override
+    public boolean showInPlayerTable() {
+        return provider.showInPlayerTable();
+    }
+}

--- a/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/PercentageDataProvider.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/PercentageDataProvider.java
@@ -1,0 +1,73 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.extension.extractor.dataprovider;
+
+import com.djrapitops.plan.extension.annotation.PercentageProvider;
+import com.djrapitops.plan.extension.builder.DataValue;
+import com.djrapitops.plan.extension.builder.ValueBuilder;
+import com.djrapitops.plan.extension.extractor.ExtensionMethod;
+import com.djrapitops.plan.extension.icon.Color;
+import com.djrapitops.plan.extension.icon.Family;
+
+import java.util.function.Supplier;
+
+public class PercentageDataProvider extends AnnotationFullDataProvider<PercentageProvider, Double, Double> {
+
+    public PercentageDataProvider(PercentageProvider provider, ExtensionMethod method) {
+        super(provider, method, double.class, Double.class);
+    }
+
+    @Override
+    public String iconName() {
+        return provider.iconName();
+    }
+
+    @Override
+    public Family iconFamily() {
+        return provider.iconFamily();
+    }
+
+    @Override
+    public Color iconColor() {
+        return provider.iconColor();
+    }
+
+    @Override
+    public String text() {
+        return provider.text();
+    }
+
+    @Override
+    public String description() {
+        return provider.description();
+    }
+
+    @Override
+    public int priority() {
+        return provider.priority();
+    }
+
+    @Override
+    public boolean showInPlayerTable() {
+        return provider.showInPlayerTable();
+    }
+
+    @Override
+    public DataValue<Double> addDataValueToBuilder(ValueBuilder builder, Supplier<Double> dataSupplier) {
+        return builder.buildPercentage(dataSupplier);
+    }
+}

--- a/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/StringDataProvider.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/StringDataProvider.java
@@ -1,0 +1,80 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.extension.extractor.dataprovider;
+
+import com.djrapitops.plan.extension.annotation.StringProvider;
+import com.djrapitops.plan.extension.builder.DataValue;
+import com.djrapitops.plan.extension.builder.ExtensionDataBuilder;
+import com.djrapitops.plan.extension.builder.ValueBuilder;
+import com.djrapitops.plan.extension.extractor.ExtensionMethod;
+import com.djrapitops.plan.extension.icon.Color;
+import com.djrapitops.plan.extension.icon.Family;
+
+import java.util.function.Supplier;
+
+public class StringDataProvider extends AnnotationFullDataProvider<StringProvider, String, String> {
+
+    public StringDataProvider(StringProvider provider, ExtensionMethod method) {
+        super(provider, method, String.class, String.class);
+    }
+
+    @Override
+    public ValueBuilder getValueBuilder(ExtensionDataBuilder dataBuilder) {
+        return super.getValueBuilder(dataBuilder)
+                .showAsPlayerPageLink(provider);
+    }
+
+    @Override
+    public DataValue<String> addDataValueToBuilder(ValueBuilder builder, Supplier<String> dataSupplier) {
+        return builder.buildString(dataSupplier);
+    }
+
+    @Override
+    public String iconName() {
+        return provider.iconName();
+    }
+
+    @Override
+    public Family iconFamily() {
+        return provider.iconFamily();
+    }
+
+    @Override
+    public Color iconColor() {
+        return provider.iconColor();
+    }
+
+    @Override
+    public String text() {
+        return provider.text();
+    }
+
+    @Override
+    public String description() {
+        return provider.description();
+    }
+
+    @Override
+    public int priority() {
+        return provider.priority();
+    }
+
+    @Override
+    public boolean showInPlayerTable() {
+        return provider.showInPlayerTable();
+    }
+}

--- a/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/TableDataProvider.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/extension/extractor/dataprovider/TableDataProvider.java
@@ -1,0 +1,37 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.extension.extractor.dataprovider;
+
+import com.djrapitops.plan.extension.annotation.TableProvider;
+import com.djrapitops.plan.extension.builder.DataValue;
+import com.djrapitops.plan.extension.builder.ValueBuilder;
+import com.djrapitops.plan.extension.extractor.ExtensionMethod;
+import com.djrapitops.plan.extension.table.Table;
+
+import java.util.function.Supplier;
+
+public class TableDataProvider extends AnnotationDataProvider<TableProvider, Table, Table> {
+
+    public TableDataProvider(TableProvider provider, ExtensionMethod method) {
+        super(provider, method, Table.class, Table.class);
+    }
+
+    @Override
+    public DataValue<Table> addDataValueToBuilder(ValueBuilder builder, Supplier<Table> dataSupplier) {
+        return builder.buildTable(dataSupplier, provider.tableColor());
+    }
+}


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description

In beginning to add `Component`s to the DataExtension API, I found the large amount of duplicated code. So I cleaned up many parts where duplicated code was being used

This is related to https://github.com/plan-player-analytics/Plan/issues/1769
