### PR TITLE
update: Fabric 1.19.3 

### DIFF
--- a/Plan/fabric/build.gradle
+++ b/Plan/fabric/build.gradle
@@ -8,9 +8,9 @@ dependencies {
 
     shadow "net.playeranalytics:platform-abstraction-layer-api:$palVersion"
 
-    minecraft "com.mojang:minecraft:1.19.1"
-    mappings "net.fabricmc:yarn:1.19.1+build.1:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.14.8"
+    minecraft "com.mojang:minecraft:22w42a"
+    mappings "net.fabricmc:yarn:22w42a+build.17:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.10"
     modImplementation('me.lucko:fabric-permissions-api:0.2-SNAPSHOT')
 
     // Fabric API
@@ -24,7 +24,7 @@ dependencies {
     ]
 
     apiModules.forEach {
-        modImplementation(fabricApi.module(it, "0.58.5+1.19.1"))
+        modImplementation(fabricApi.module(it, "0.64.0+1.19.2"))
     }
 
     testImplementation project(path: ":common", configuration: 'testArtifacts')

--- a/Plan/fabric/build.gradle
+++ b/Plan/fabric/build.gradle
@@ -8,8 +8,8 @@ dependencies {
 
     shadow "net.playeranalytics:platform-abstraction-layer-api:$palVersion"
 
-    minecraft "com.mojang:minecraft:22w42a"
-    mappings "net.fabricmc:yarn:22w42a+build.17:v2"
+    minecraft "com.mojang:minecraft:22w44a"
+    mappings "net.fabricmc:yarn:22w44a+build.2:v2"
     modImplementation "net.fabricmc:fabric-loader:0.14.10"
     modImplementation('me.lucko:fabric-permissions-api:0.2-SNAPSHOT')
 

--- a/Plan/fabric/build.gradle
+++ b/Plan/fabric/build.gradle
@@ -8,9 +8,9 @@ dependencies {
 
     shadow "net.playeranalytics:platform-abstraction-layer-api:$palVersion"
 
-    minecraft "com.mojang:minecraft:22w44a"
-    mappings "net.fabricmc:yarn:22w44a+build.2:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.14.10"
+    minecraft "com.mojang:minecraft:1.19.3-rc1"
+    mappings "net.fabricmc:yarn:1.19.3-rc1+build.2:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.11"
     modImplementation('me.lucko:fabric-permissions-api:0.2-SNAPSHOT')
 
     // Fabric API
@@ -24,7 +24,7 @@ dependencies {
     ]
 
     apiModules.forEach {
-        modImplementation(fabricApi.module(it, "0.64.0+1.19.2"))
+        modImplementation(fabricApi.module(it, "0.68.1+1.19.3"))
     }
 
     testImplementation project(path: ":common", configuration: 'testArtifacts')

--- a/Plan/fabric/src/main/java/net/playeranalytics/plan/gathering/listeners/fabric/ChatListener.java
+++ b/Plan/fabric/src/main/java/net/playeranalytics/plan/gathering/listeners/fabric/ChatListener.java
@@ -84,7 +84,7 @@ public class ChatListener implements FabricListener {
             if (!isEnabled) {
                 return;
             }
-            onChat(sender, message.getContent().getString());
+            onChat(sender, message.getSignedContent());
         });
 
         this.enable();

--- a/Plan/fabric/src/main/java/net/playeranalytics/plan/gathering/listeners/fabric/ChatListener.java
+++ b/Plan/fabric/src/main/java/net/playeranalytics/plan/gathering/listeners/fabric/ChatListener.java
@@ -58,12 +58,12 @@ public class ChatListener implements FabricListener {
         this.errorLogger = errorLogger;
     }
 
-    public void onChat(ServerPlayerEntity player, String message) {
+    public void onChat(ServerPlayerEntity player) {
 
         try {
             actOnChatEvent(player);
         } catch (Exception e) {
-            errorLogger.error(e, ErrorContext.builder().related(player, message).build());
+            errorLogger.error(e, ErrorContext.builder().related(player).build());
         }
     }
 
@@ -84,7 +84,7 @@ public class ChatListener implements FabricListener {
             if (!isEnabled) {
                 return;
             }
-            onChat(sender, message.getSignedContent());
+            onChat(sender);
         });
 
         this.enable();

--- a/Plan/fabric/src/main/java/net/playeranalytics/plan/identification/properties/FabricServerProperties.java
+++ b/Plan/fabric/src/main/java/net/playeranalytics/plan/identification/properties/FabricServerProperties.java
@@ -32,9 +32,9 @@ public class FabricServerProperties extends ServerProperties {
                 "Fabric",
                 server.getServerPort(),
                 server.getVersion(),
-                FabricLoader.getInstance().getModContainer("fabric").orElseThrow().getMetadata().getVersion().getFriendlyString() +
+                FabricLoader.getInstance().getModContainer("fabric").map(container -> container.getMetadata().getVersion().getFriendlyString()).orElse("Unknown") +
                         " (API), " +
-                        FabricLoader.getInstance().getModContainer("fabricloader").orElseThrow().getMetadata().getVersion().getFriendlyString() +
+                        FabricLoader.getInstance().getModContainer("fabricloader").map(modContainer -> modContainer.getMetadata().getVersion().getFriendlyString()).orElse("Unknown") +
                         " (loader)",
                 () -> (server.getServerIp() == null) ? "" : server.getServerIp(),
                 server.getProperties().maxPlayers


### PR DESCRIPTION
Mojang aims to release 1.19.3 on 6th of December, the latest release candidate will most likely be identical to the full release!
- Updates fabric module to 1.19.3 (and makes it backwards compatible, with at least 1.19.2)
- Prevents crashes if fabric-api mod is not present, but all required modules are present.