### PR TITLE
3091/mariadb driver support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           MYSQL_PASSWORD: password
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: password
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
 
     steps:
       - name: 📥 Checkout git repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:latest
+        image: mariadb:11.1-rc
         ports:
           - 3306
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:10.6.14
+        image: mariadb:latest
         ports:
           - 3306
         env:

--- a/Plan/build.gradle
+++ b/Plan/build.gradle
@@ -88,6 +88,7 @@ subprojects {
         jettyVersion = "11.0.15"
         caffeineVersion = "2.9.2"
         mysqlVersion = "8.0.33"
+        mariadbVersion = "3.1.4"
         sqliteVersion = "3.41.2.1"
         adventureVersion = "4.14.0"
         hikariVersion = "5.0.1"
@@ -134,8 +135,9 @@ subprojects {
         // Awaitility (Concurrent wait conditions)
 
         // Testing dependencies required by Plan
-        testImplementation "org.xerial:sqlite-jdbc:$sqliteVersion"    // SQLite
-        testImplementation "mysql:mysql-connector-java:$mysqlVersion" // MySQL
+        testImplementation "org.xerial:sqlite-jdbc:$sqliteVersion" // SQLite
+        testImplementation "com.mysql:mysql-connector-j:$mysqlVersion" // MySQL
+        testImplementation "org.mariadb.jdbc:mariadb-java-client:$mariadbVersion" // MariaDB
     }
 
     configurations {

--- a/Plan/common/build.gradle
+++ b/Plan/common/build.gradle
@@ -10,16 +10,25 @@ plugins {
 configurations {
     // Runtime downloading scopes
     mysqlDriver
+    mariadbDriver
     sqliteDriver
     ipAddressMatcher
-    testImplementation.extendsFrom mysqlDriver, sqliteDriver, ipAddressMatcher
-    compileOnly.extendsFrom mysqlDriver, sqliteDriver, ipAddressMatcher
+    testImplementation.extendsFrom mysqlDriver, mariadbDriver, sqliteDriver, ipAddressMatcher
+    compileOnly.extendsFrom mysqlDriver, mariadbDriver, sqliteDriver, ipAddressMatcher
 
     swaggerJson // swagger.json configuration
 }
 
 task generateResourceForMySQLDriver(type: GenerateDependencyDownloadResourceTask) {
     var conf = configurations.mysqlDriver
+    configuration = conf
+    file = "assets/plan/dependencies/" + conf.name + ".txt"
+    // Not necessary to include in the resource
+    includeShadowJarRelocations = false
+}
+
+task generateResourceForMariaDBDriver(type: GenerateDependencyDownloadResourceTask) {
+    var conf = configurations.mariadbDriver
     configuration = conf
     file = "assets/plan/dependencies/" + conf.name + ".txt"
     // Not necessary to include in the resource
@@ -52,7 +61,8 @@ dependencies {
         // Effectively disables relocating
         exclude module: "jar-relocator"
     }
-    mysqlDriver "mysql:mysql-connector-java:$mysqlVersion"
+    mysqlDriver "com.mysql:mysql-connector-j:$mysqlVersion"
+    mariadbDriver "org.mariadb.jdbc:mariadb-java-client:$mariadbVersion"
     sqliteDriver "org.xerial:sqlite-jdbc:$sqliteVersion"
     ipAddressMatcher "com.github.seancfoley:ipaddress:$ipAddressMatcherVersion"
 

--- a/Plan/common/src/main/java/com/djrapitops/plan/exceptions/database/MariaDB11Exception.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/exceptions/database/MariaDB11Exception.java
@@ -1,0 +1,29 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.exceptions.database;
+
+/**
+ * Exception thrown when MySQL driver can't connect to MariaDB.
+ *
+ * @author AuroraLS3
+ */
+public class MariaDB11Exception extends DBInitException {
+
+    public MariaDB11Exception(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/database/MySQLDB.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/database/MySQLDB.java
@@ -83,7 +83,7 @@ public class MySQLDB extends SQLDB {
             String driverFile = useMariaDbDriver ? "dependencies/mariadbDriver.txt" : "dependencies/mysqlDriver.txt";
             return files.getResourceFromJar(driverFile).asLines();
         } catch (IOException e) {
-            throw new DBInitException("Failed to get MySQL dependency information", e);
+            throw new DBInitException("Failed to get " + (useMariaDbDriver ? "MariaDB" : "MySQL") + " dependency information", e);
         }
     }
 
@@ -93,7 +93,7 @@ public class MySQLDB extends SQLDB {
     @Override
     public void setupDataSource() {
         if (driverClassLoader == null) {
-            logger.info("Downloading MySQL Driver, this may take a while...");
+            logger.info("Downloading " + (useMariaDbDriver ? "MariaDB" : "MySQL") + " Driver, this may take a while...");
             downloadDriver();
         }
 

--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/database/queries/schema/MySQLSchemaQueries.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/database/queries/schema/MySQLSchemaQueries.java
@@ -19,12 +19,14 @@ package com.djrapitops.plan.storage.database.queries.schema;
 import com.djrapitops.plan.storage.database.queries.HasMoreThanZeroQueryStatement;
 import com.djrapitops.plan.storage.database.queries.Query;
 import com.djrapitops.plan.storage.database.queries.QueryStatement;
+import org.intellij.lang.annotations.Language;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.djrapitops.plan.storage.database.sql.building.Sql.*;
 
@@ -37,6 +39,12 @@ public class MySQLSchemaQueries {
 
     private MySQLSchemaQueries() {
         /* Static method class */
+    }
+
+    public static Query<Optional<String>> getVersion() {
+        @Language("MySQL")
+        String sql = "SELECT VERSION()";
+        return db -> db.queryOptional(sql, row -> row.getString(1));
     }
 
     public static Query<Boolean> doesTableExist(String tableName) {

--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/database/sql/tables/WorldTable.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/database/sql/tables/WorldTable.java
@@ -50,8 +50,8 @@ public class WorldTable {
 
     public static final String SELECT_WORLD_ID_STATEMENT = '(' +
             SELECT + TABLE_NAME + '.' + ID + FROM + TABLE_NAME +
-            WHERE + '(' + NAME + "=?)" +
-            AND + '(' + TABLE_NAME + '.' + SERVER_UUID + "=?)" +
+            WHERE + NAME + "=?" +
+            AND + TABLE_NAME + '.' + SERVER_UUID + "=?" +
             " LIMIT 1)";
 
     private WorldTable() {


### PR DESCRIPTION
### Description

Fixes #3091 when using MariaDB 11.1.1 or newer.

11.0.2 will cause issues so support for it is disabled via an implicit DBInitException.