### PR TITLE
Fix join address gathering

### DIFF
--- a/Plan/bukkit/src/main/java/com/djrapitops/plan/gathering/listeners/bukkit/PlayerOnlineListener.java
+++ b/Plan/bukkit/src/main/java/com/djrapitops/plan/gathering/listeners/bukkit/PlayerOnlineListener.java
@@ -87,12 +87,12 @@ public class PlayerOnlineListener implements Listener {
             if (!address.isEmpty()) {
                 if (address.contains(":")) {
                     address = address.substring(0, address.lastIndexOf(':'));
-                    if (address.contains("\u0000")) {
-                        address = address.substring(0, address.indexOf('\u0000'));
-                    }
-                    if (address.contains("fml")) {
-                        address = address.substring(0, address.lastIndexOf("fml"));
-                    }
+                }
+                if (address.contains("\u0000")) {
+                    address = address.substring(0, address.indexOf('\u0000'));
+                }
+                if (address.contains("fml")) {
+                    address = address.substring(0, address.lastIndexOf("fml"));
                 }
                 joinAddressCache.put(playerUUID, address);
             }

--- a/Plan/bukkit/src/main/java/com/djrapitops/plan/gathering/listeners/bukkit/PlayerOnlineListener.java
+++ b/Plan/bukkit/src/main/java/com/djrapitops/plan/gathering/listeners/bukkit/PlayerOnlineListener.java
@@ -85,12 +85,14 @@ public class PlayerOnlineListener implements Listener {
 
             String address = event.getHostname();
             if (!address.isEmpty()) {
-                address = address.substring(0, address.lastIndexOf(':'));
-                if (address.contains("\u0000")) {
-                    address = address.substring(0, address.indexOf('\u0000'));
-                }
-                if (address.contains("fml")) {
-                    address = address.substring(0, address.lastIndexOf("fml"));
+                if (address.contains(":")) {
+                    address = address.substring(0, address.lastIndexOf(':'));
+                    if (address.contains("\u0000")) {
+                        address = address.substring(0, address.indexOf('\u0000'));
+                    }
+                    if (address.contains("fml")) {
+                        address = address.substring(0, address.lastIndexOf("fml"));
+                    }
                 }
                 joinAddressCache.put(playerUUID, address);
             }

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
@@ -107,7 +107,8 @@ public class Contributors {
             new Contributor("lis2a", LANG),
             new Contributor("ToxiWoxi", CODE),
             new Contributor("xlanyleeet", LANG),
-            new Contributor("Jumala9163", LANG)
+            new Contributor("Jumala9163", LANG),
+            new Contributor("Dreeam-qwq", CODE)
     };
 
     private Contributors() {


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
In some situations, the event.getHostname() will return exactly player's join adress without a port number, like `xxx.myserver.com`, so I add a condition check to prevent get that nonexistent ':' , to prevent the error like:

```
java.lang.StringIndexOutOfBoundsException: Range [0, -1) out of bounds for length 14
   java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:55)
   java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:52)
   java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:213)
   java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:210)
   java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98)
   java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Preconditions.java:112)
   java.base/jdk.internal.util.Preconditions.checkFromToIndex(Preconditions.java:349)
   java.base/java.lang.String.checkBoundsBeginEnd(String.java:4861)
   java.base/java.lang.String.substring(String.java:2830)
   [大数据]Plan-5.6-SNAPSHOT.jar//com.djrapitops.plan.gathering.listeners.bukkit.PlayerOnlineListener.onPlayerLogin(PlayerOnlineListener.java:88)
   com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor98.execute(Unknown Source)
   org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77)
   org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:72)
   io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:59)
   io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:126)
   org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:616)
   net.minecraft.server.players.PlayerList.canPlayerLogin(PlayerList.java:770)
   net.minecraft.server.network.LoginListener.c(LoginListener.java:235)
   net.minecraft.server.network.LoginListener.e(LoginListener.java:88)
   net.minecraft.network.NetworkManager.d(NetworkManager.java:602)
   net.minecraft.server.network.ServerConnection.c(ServerConnection.java:240)
   net.minecraft.server.MinecraftServer.b(MinecraftServer.java:1557)
   net.minecraft.server.dedicated.DedicatedServer.b(DedicatedServer.java:494)
   net.minecraft.server.MinecraftServer.a(MinecraftServer.java:1389)
   net.minecraft.server.MinecraftServer.w(MinecraftServer.java:1162)
   net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:304)
   java.base/java.lang.Thread.run(Thread.java:1583)
```

