### PR TITLE
V5.3.7 Bug Fix Fork - Litebans r.includes error

### DIFF
--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
@@ -117,7 +117,8 @@ public class Contributors {
             new Contributor("ZhangYuheng", CODE),
             new Contributor("Zaemong", LANG),
             new Contributor("TWJohnJohn20116", LANG),
-            new Contributor("YannicHock", CODE)
+            new Contributor("YannicHock", CODE),
+            new Contributor("SaolGhra", CODE)
     };
 
     private Contributors() {

--- a/Plan/react/dashboard/src/components/extensions/ExtensionTable.jsx
+++ b/Plan/react/dashboard/src/components/extensions/ExtensionTable.jsx
@@ -44,7 +44,11 @@ const ExtensionDataTable = ({table}) => {
         order: [[1, "desc"]]
     }
     const rowKeyFunction = (row, column) => {
-        return JSON.stringify(Object.entries(row).filter(e => e[0].includes('Value'))) + "-" + JSON.stringify(column?.data?._);
+        // Generate a unique key by joining all value fields as strings
+        const valueFields = Object.entries(row)
+            .filter(e => typeof e[0] === 'string' && e[0].includes('Value'))
+            .map(e => String(e[1]));
+        return valueFields.join('-') + '-' + String(column?.data?._);
     }
 
     return (

--- a/Plan/react/dashboard/src/components/extensions/ExtensionTable.jsx
+++ b/Plan/react/dashboard/src/components/extensions/ExtensionTable.jsx
@@ -44,7 +44,6 @@ const ExtensionDataTable = ({table}) => {
         order: [[1, "desc"]]
     }
     const rowKeyFunction = (row, column) => {
-        // Generate a unique key by joining all value fields as strings
         const valueFields = Object.entries(row)
             .filter(e => typeof e[0] === 'string' && e[0].includes('Value'))
             .map(e => String(e[1]));


### PR DESCRIPTION
Fix 'r.includes is not a function' on Litebans Kick Page ([#4169](https://github.com/plan-player-analytics/Plan/issues/4169))

### Description

This PR fixes a JavaScript runtime error on the LiteBans Kick page where `r.includes` would throw "is not a function." The issue was due to `r` not always being an array. The fix ensures `r` is an array before `.includes` is called, resolving the error that persisted across pages until refresh.

### Checklist

- [x] Added my name to `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [ ] If locale changes were made, added LangCode with my name in `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Testing

Tested on a local Plan instance: the error no longer appears and page navigation works as expected.

Thank you!