### PR TITLE
Update to DependencyDownload 2.0.0 and implement cleaning the libraries directory

### DIFF
--- a/Plan/build.gradle
+++ b/Plan/build.gradle
@@ -82,7 +82,7 @@ subprojects {
         slf4jVersion = "2.0.17"
         geoIpVersion = "4.3.1"
         gsonVersion = "2.13.1"
-        dependencyDownloadVersion = "1.3.1"
+        dependencyDownloadVersion = "2.0.0"
         ipAddressMatcherVersion = "5.5.1"
         jasyptVersion = "1.9.3"
 

--- a/Plan/common/build.gradle
+++ b/Plan/common/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation "net.playeranalytics:platform-abstraction-layer-api:$palVersion"
 
     compileOnly "net.kyori:adventure-api:$adventureVersion"
-    implementation("dev.vankka:dependencydownload-runtime:$dependencyDownloadVersion") {
+    api("dev.vankka:dependencydownload-runtime:$dependencyDownloadVersion") {
         // Effectively disables relocating
         exclude module: "jar-relocator"
     }

--- a/Plan/common/src/main/java/com/djrapitops/plan/PlanSystem.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/PlanSystem.java
@@ -35,10 +35,12 @@ import com.djrapitops.plan.storage.file.PlanFiles;
 import com.djrapitops.plan.utilities.logging.ErrorContext;
 import com.djrapitops.plan.utilities.logging.ErrorLogger;
 import com.djrapitops.plan.version.VersionChecker;
+import dev.vankka.dependencydownload.ApplicationDependencyManager;
 import net.playeranalytics.plugin.server.PluginLogger;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.io.IOException;
 
 /**
  * PlanSystem contains everything Plan needs to run.
@@ -74,6 +76,7 @@ public class PlanSystem implements SubSystem {
     private final ApiServices apiServices;
     private final PluginLogger logger;
     private final ErrorLogger errorLogger;
+    private final ApplicationDependencyManager applicationDependencyManager;
 
     @Inject
     public PlanSystem(
@@ -93,6 +96,7 @@ public class PlanSystem implements SubSystem {
             DeliveryUtilities deliveryUtilities,
             PluginLogger logger,
             ErrorLogger errorLogger,
+            ApplicationDependencyManager applicationDependencyManager,
             ApiServices apiServices, // API v5
             @SuppressWarnings("deprecation") PlanAPI.PlanAPIHolder apiHolder, GatheringUtilities gatheringUtilities // Deprecated PlanAPI, backwards compatibility
     ) {
@@ -113,6 +117,7 @@ public class PlanSystem implements SubSystem {
         this.gatheringUtilities = gatheringUtilities;
         this.logger = logger;
         this.errorLogger = errorLogger;
+        this.applicationDependencyManager = applicationDependencyManager;
         this.apiServices = apiServices;
 
         logger.info("§2");
@@ -191,6 +196,12 @@ public class PlanSystem implements SubSystem {
         Formatters.clearSingleton();
 
         apiServices.disableExtensionDataUpdates();
+
+        try {
+            applicationDependencyManager.cleanupCacheDirectory();
+        } catch (IOException e) {
+            logger.warn("Failed to cleanup dependency cache directory", e);
+        }
 
         disableSystems(
                 taskSystem,

--- a/Plan/common/src/main/java/com/djrapitops/plan/modules/SystemObjectProvidingModule.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/modules/SystemObjectProvidingModule.java
@@ -35,11 +35,14 @@ import com.google.gson.Gson;
 import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.ElementsIntoSet;
+import dev.vankka.dependencydownload.ApplicationDependencyManager;
+import dev.vankka.dependencydownload.path.DependencyPathProvider;
 import net.playeranalytics.plugin.PluginInformation;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -121,6 +124,13 @@ public class SystemObjectProvidingModule {
             JSONFileStorage jsonFileStorage
     ) {
         return new JSONMemoryStorageShim(config, jsonFileStorage);
+    }
+
+    @Provides
+    @Singleton
+    ApplicationDependencyManager applicationDependencyManager(@Named("dataFolder") File dataFolder) {
+        Path librariesDirectory = dataFolder.toPath().resolve("libraries");
+        return new ApplicationDependencyManager(DependencyPathProvider.directory(librariesDirectory));
     }
 
 }

--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/database/MySQLDB.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/database/MySQLDB.java
@@ -33,6 +33,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.pool.HikariPool;
 import dagger.Lazy;
+import dev.vankka.dependencydownload.ApplicationDependencyManager;
 import net.playeranalytics.plugin.scheduling.RunnableFactory;
 import net.playeranalytics.plugin.server.PluginLogger;
 
@@ -65,9 +66,19 @@ public class MySQLDB extends SQLDB {
             Lazy<ServerInfo> serverInfo,
             RunnableFactory runnableFactory,
             PluginLogger pluginLogger,
-            ErrorLogger errorLogger
+            ErrorLogger errorLogger,
+            ApplicationDependencyManager applicationDependencyManager
     ) {
-        super(() -> serverInfo.get().getServerUUID(), locale, config, files, runnableFactory, pluginLogger, errorLogger);
+        super(
+                () -> serverInfo.get().getServerUUID(),
+                locale,
+                config,
+                files,
+                runnableFactory,
+                pluginLogger,
+                errorLogger,
+                applicationDependencyManager
+        );
     }
 
     private static synchronized void increment() {

--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/database/SQLiteDB.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/database/SQLiteDB.java
@@ -27,6 +27,7 @@ import com.djrapitops.plan.utilities.MiscUtils;
 import com.djrapitops.plan.utilities.SemaphoreAccessCounter;
 import com.djrapitops.plan.utilities.logging.ErrorLogger;
 import dagger.Lazy;
+import dev.vankka.dependencydownload.ApplicationDependencyManager;
 import net.playeranalytics.plugin.scheduling.RunnableFactory;
 import net.playeranalytics.plugin.scheduling.Task;
 import net.playeranalytics.plugin.server.PluginLogger;
@@ -70,9 +71,19 @@ public class SQLiteDB extends SQLDB {
             Lazy<ServerInfo> serverInfo,
             RunnableFactory runnableFactory,
             PluginLogger logger,
-            ErrorLogger errorLogger
+            ErrorLogger errorLogger,
+            ApplicationDependencyManager applicationDependencyManager
     ) {
-        super(() -> serverInfo.get().getServerUUID(), locale, config, files, runnableFactory, logger, errorLogger);
+        super(
+                () -> serverInfo.get().getServerUUID(),
+                locale,
+                config,
+                files,
+                runnableFactory,
+                logger,
+                errorLogger,
+                applicationDependencyManager
+        );
         dbName = databaseFile.getName();
         this.databaseFile = databaseFile;
         connectionLock = new SemaphoreAccessCounter();
@@ -240,6 +251,7 @@ public class SQLiteDB extends SQLDB {
         private final PluginLogger logger;
         private final ErrorLogger errorLogger1;
         private final PlanFiles files;
+        private final ApplicationDependencyManager applicationDependencyManager;
 
         @Inject
         public Factory(
@@ -249,7 +261,8 @@ public class SQLiteDB extends SQLDB {
                 Lazy<ServerInfo> serverInfo,
                 RunnableFactory runnableFactory,
                 PluginLogger logger,
-                ErrorLogger errorLogger1
+                ErrorLogger errorLogger1,
+                ApplicationDependencyManager applicationDependencyManager
         ) {
             this.locale = locale;
             this.config = config;
@@ -258,6 +271,7 @@ public class SQLiteDB extends SQLDB {
             this.runnableFactory = runnableFactory;
             this.logger = logger;
             this.errorLogger1 = errorLogger1;
+            this.applicationDependencyManager = applicationDependencyManager;
         }
 
         public SQLiteDB usingDefaultFile() {
@@ -271,7 +285,8 @@ public class SQLiteDB extends SQLDB {
         public SQLiteDB usingFile(File databaseFile) {
             return new SQLiteDB(databaseFile,
                     locale, config, files, serverInfo,
-                    runnableFactory, logger, errorLogger1
+                    runnableFactory, logger, errorLogger1,
+                    applicationDependencyManager
             );
         }
 

--- a/Plan/common/src/test/java/utilities/dagger/TestSystemObjectProvidingModule.java
+++ b/Plan/common/src/test/java/utilities/dagger/TestSystemObjectProvidingModule.java
@@ -27,6 +27,8 @@ import com.djrapitops.plan.utilities.logging.ErrorLogger;
 import com.google.gson.Gson;
 import dagger.Module;
 import dagger.Provides;
+import dev.vankka.dependencydownload.ApplicationDependencyManager;
+import dev.vankka.dependencydownload.path.DependencyPathProvider;
 import utilities.TestErrorLogger;
 import utilities.TestResources;
 
@@ -92,5 +94,11 @@ public class TestSystemObjectProvidingModule {
     @Singleton
     ErrorLogger provideErrorLogger() {
         return new TestErrorLogger();
+    }
+
+    @Provides
+    @Singleton
+    ApplicationDependencyManager applicationDependencyManager(@Named("dataFolder") File dataFolder) {
+        return new ApplicationDependencyManager(DependencyPathProvider.directory(dataFolder.toPath()));
     }
 }


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description

Updates DependencyDownload 2.0.0 which consists mostly of renames. And adds ApplicationDependencyManager for keeping track of loaded dependencies and then cleaning up old dependencies (in practice: deleting jar files from the `libraries` directory that aren't included in the ApplicationDependencyManager when cleaning up)

Implements https://github.com/plan-player-analytics/Plan/issues/3438
