### PR TITLE
Add regex support for filtered join addresses setting

### DIFF
--- a/Plan/build.gradle
+++ b/Plan/build.gradle
@@ -90,7 +90,7 @@ subprojects {
         placeholderapiVersion = "2.11.5"
         nkPlaceholderapiVersion = "1.4-SNAPSHOT"
 
-        junitVersion = "5.13.4"
+        junitVersion = "6.0.1"
         mockitoVersion = "5.19.0"
         seleniumVersion = "4.35.0"
         testContainersVersion = "1.21.3"
@@ -121,7 +121,7 @@ subprojects {
         }
 
         // Required for JUnit to discover tests in modules.
-        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitVersion")
     }
 
     test {

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
@@ -118,7 +118,8 @@ public class Contributors {
             new Contributor("Zaemong", LANG),
             new Contributor("TWJohnJohn20116", LANG),
             new Contributor("YannicHock", CODE),
-            new Contributor("SaolGhra", CODE)
+            new Contributor("SaolGhra", CODE),
+            new Contributor("Jsinco", CODE)
     };
 
     private Contributors() {

--- a/Plan/common/src/main/resources/assets/plan/bungeeconfig.yml
+++ b/Plan/common/src/main/resources/assets/plan/bungeeconfig.yml
@@ -119,7 +119,7 @@ Data_gathering:
     # Does not affect already gathered data
     Preserve_case: false
     Preserve_invalid: false
-    # Replaces these join addresses with unknown
+    # Replaces these join addresses with unknown, supports regex
     Filter_out_from_data:
       - "play.example.com"
 # -----------------------------------------------------

--- a/Plan/common/src/main/resources/assets/plan/config.yml
+++ b/Plan/common/src/main/resources/assets/plan/config.yml
@@ -123,7 +123,7 @@ Data_gathering:
     # Does not affect already gathered data
     Preserve_case: false
     Preserve_invalid: false
-    # Replaces these join addresses with unknown
+    # Replaces these join addresses with unknown, supports regex
     Filter_out_from_data:
       - "play.example.com"
 # -----------------------------------------------------


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [ ] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
Please describe your pull request.

- Modifies implementations of `FILTER_JOIN_ADDRESSES` to use `Pattern#matches` instead of `List#contains(String)` for regex support in the filtered join address portion of the config.
- Bumps junit jupiter's version to `6.0.1`.
- Changed some comments in the default configs.

That should be everything ^. No manual tests, but automatated tests pass fine.


Thank you!
