### PR TITLE
Fix proxy HTTPS address comparison missing replace argument

### DIFF
--- a/Plan/react/dashboard/src/service/backendConfiguration.js
+++ b/Plan/react/dashboard/src/service/backendConfiguration.js
@@ -10,7 +10,7 @@ const isCurrentAddress = (address) => {
     let is = window.location.href.startsWith(address);
     const usingProxyHttps = window.location.href.startsWith("https") && !address.startsWith("https");
     if (usingProxyHttps) {
-        is = window.location.href.replace('https', '').startsWith(address.replace('http'));
+        is = window.location.href.replace('https', '').startsWith(address.replace('http', ''));
     }
     if (!is) {
         console.warn(`Configured address ${address} did not match start of ${window.location.href}, falling back to relative address. Configure 'Webserver.Alternative_IP' settings to point to your address.`)


### PR DESCRIPTION
### Your checklist for this pull request

- [x] N/A — no contributor name needed for a one-character fix
- [x] No locale changes

### Description

`address.replace('http')` is missing the second argument — JS replaces the match with `"undefined"`, so `isCurrentAddress()` always fails behind an HTTPS reverse proxy.

Adds the missing empty string: `address.replace('http', '')`.

Tested on a live deployment (Plan v5.7 b3247 behind nginx HTTPS proxy at a subpath).