### PR TITLE
Align Java compile options

### DIFF
--- a/Plan/api/build.gradle
+++ b/Plan/api/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 
 compileJava {
     options.release = 8
-    sourceCompatibility = "${JavaVersion.VERSION_1_8}"
 }
 
 def apiVersion = "5.7-R0.2"

--- a/Plan/build.gradle
+++ b/Plan/build.gradle
@@ -49,11 +49,6 @@ subprojects {
     apply plugin: "checkstyle"
     apply plugin: "jacoco"
 
-    compileJava {
-        options.release = 11
-        sourceCompatibility = "${JavaVersion.VERSION_11}"
-    }
-
     ext {
         daggerVersion = "2.59.2"
 
@@ -146,8 +141,14 @@ subprojects {
         }
     }
 
-    // Fix for UTF-8 files showing with wrong encoding when compiled on Windows machines.
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(25)
+        }
+    }
+
     tasks.withType(JavaCompile).configureEach {
+        options.release = 25
         options.encoding = "UTF-8"
         options.fork = true
     }

--- a/Plan/bukkit/build.gradle
+++ b/Plan/bukkit/build.gradle
@@ -20,6 +20,10 @@ dependencies {
     testImplementation "com.destroystokyo.paper:paper-api:$paperVersion"
 }
 
+compileJava {
+    options.release = 11
+}
+
 processResources {
     inputs.property("version", fullVersion)
 

--- a/Plan/bungeecord/build.gradle
+++ b/Plan/bungeecord/build.gradle
@@ -13,6 +13,10 @@ dependencies {
     testImplementation(project(":extensions:adventure"))
 }
 
+compileJava {
+    options.release = 11
+}
+
 processResources {
     inputs.property("version", fullVersion)
 

--- a/Plan/common/build.gradle
+++ b/Plan/common/build.gradle
@@ -9,10 +9,6 @@ plugins {
     id "io.swagger.core.v3.swagger-gradle-plugin" version "2.2.46"
 }
 
-compileTestFixturesJava {
-    sourceCompatibility = "${JavaVersion.VERSION_17}"
-}
-
 configurations {
     // Runtime downloading scopes
     mysqlDriver
@@ -120,6 +116,10 @@ dependencies {
 
     testImplementation "com.google.dagger:dagger:$daggerVersion"
     testAnnotationProcessor "com.google.dagger:dagger-compiler:$daggerVersion"
+}
+
+compileJava {
+    options.release = 11
 }
 
 test {

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
@@ -78,7 +78,7 @@ public class Contributors {
             new Contributor("QuakyCZ", LANG),
             new Contributor("MrFriggo", LANG),
             new Contributor("vacoup", CODE),
-            new Contributor("Kopo942", CODE),
+            new Contributor("AnttiMK", CODE),
             new Contributor("WolverStones", LANG),
             new Contributor("BruilsiozPro", LANG),
             new Contributor("AppleMacOS", CODE),

--- a/Plan/extensions/adventure/build.gradle
+++ b/Plan/extensions/adventure/build.gradle
@@ -12,6 +12,10 @@ dependencies {
     api "net.kyori:adventure-text-minimessage:$adventureVersion"
 }
 
+compileJava {
+    options.release = 11
+}
+
 tasks.named("shadowJar", ShadowJar) {
     relocate "net.kyori", "plan.net.kyori"
 }

--- a/Plan/extensions/adventure/build.gradle
+++ b/Plan/extensions/adventure/build.gradle
@@ -7,7 +7,11 @@ apply plugin: "com.gradleup.shadow"
 
 dependencies {
     compileOnly project(":common")
-    api "net.kyori:adventure-text-serializer-gson:$adventureVersion"
+    api("net.kyori:adventure-text-serializer-gson:$adventureVersion") {
+        // Exclude Gson to use our version and not double-shade
+        // a potentially older version when building :plugin module
+        exclude(group: "com.google.code.gson", module: "gson")
+    }
     api "net.kyori:adventure-text-serializer-legacy:$adventureVersion"
     api "net.kyori:adventure-text-minimessage:$adventureVersion"
 }

--- a/Plan/extensions/build.gradle
+++ b/Plan/extensions/build.gradle
@@ -47,3 +47,7 @@ dependencies {
     implementation "net.playeranalytics:Extension-Vault:1.7-R1.3"
     implementation "net.playeranalytics:Extension-ViaVersion:4.0.1-R1.5"
 }
+
+compileJava {
+    options.release = 11
+}

--- a/Plan/fabric/build.gradle
+++ b/Plan/fabric/build.gradle
@@ -38,9 +38,8 @@ dependencies {
     testImplementation(project(":extensions:adventure"))
 }
 
-tasks.withType(JavaCompile).configureEach {
-    options.release.set(25)
-    sourceCompatibility = "${JavaVersion.VERSION_25}"
+compileJava {
+    options.release = 25
 }
 
 processResources {

--- a/Plan/folia/build.gradle
+++ b/Plan/folia/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: "com.gradleup.shadow"
 
-tasks.withType(JavaCompile).configureEach {
-    options.release.set(17)
-}
-
 dependencies {
     runtimeOnly "net.playeranalytics:platform-abstraction-layer-folia:$palVersion"
+}
+
+compileJava {
+    options.release = 17
 }

--- a/Plan/folia/build.gradle
+++ b/Plan/folia/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: "com.gradleup.shadow"
-
 dependencies {
     runtimeOnly "net.playeranalytics:platform-abstraction-layer-folia:$palVersion"
 }

--- a/Plan/nukkit/build.gradle
+++ b/Plan/nukkit/build.gradle
@@ -16,6 +16,10 @@ dependencies {
     testImplementation(project(":extensions:adventure"))
 }
 
+compileJava {
+    options.release = 11
+}
+
 processResources {
     inputs.property("version", fullVersion)
 

--- a/Plan/plugin/build.gradle
+++ b/Plan/plugin/build.gradle
@@ -13,13 +13,10 @@ dependencies {
     implementation project(":common")
     implementation project(":bukkit")
     implementation project(":nukkit")
-    implementation project(path: ":sponge", configuration: "shadow")
+    implementation project(":sponge")
     implementation project(":bungeecord")
-    // Shadow configuration required to depend on Velocity due to newer Java version
-    implementation project(path: ":velocity", configuration: "shadow")
-
-    // Shadow configuration required to depend on Folia due to newer Java version
-    implementation project(path: ":folia", configuration: "shadow")
+    implementation project(":velocity")
+    implementation project(":folia")
 
     // Shadow configuration required to only relocate adventure calls in ComponentConverter, not whole plugin
     implementation project(path: ":extensions:adventure", configuration: "shadow")

--- a/Plan/sponge/build.gradle
+++ b/Plan/sponge/build.gradle
@@ -6,10 +6,6 @@ plugins {
     id "org.spongepowered.gradle.vanilla" version "0.2.2"
 }
 
-// Shadow plugin applied even though shadow is not used in the module,
-// so that VanillaGradle doesn't include Minecraft in runtimeClassPath
-apply plugin: "com.gradleup.shadow"
-
 dependencies {
     implementation project(":common")
 

--- a/Plan/sponge/build.gradle
+++ b/Plan/sponge/build.gradle
@@ -76,6 +76,6 @@ minecraft {
     platform(MinecraftPlatform.SERVER)
 }
 
-tasks.withType(JavaCompile).configureEach {
-    options.release.set(21)
+compileJava {
+    options.release = 21
 }

--- a/Plan/velocity/build.gradle
+++ b/Plan/velocity/build.gradle
@@ -2,8 +2,6 @@ plugins {
     id "net.kyori.blossom" version "2.2.0"
 }
 
-apply plugin: "com.gradleup.shadow"
-
 compileJava {
     dependsOn generateTemplates
 }

--- a/Plan/velocity/build.gradle
+++ b/Plan/velocity/build.gradle
@@ -43,6 +43,6 @@ dependencies {
     testImplementation(project(":extensions:adventure"))
 }
 
-tasks.withType(JavaCompile).configureEach {
-    options.release.set(21)
+compileJava {
+    options.release = 21
 }


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`
- [x] If PR:ing locale changes also add a LangCode with your name `/Plan/common/src/main/java/com/djrapitops/plan/settings/locale/LangCode.java`

### Description
Aligns Java compile options so that application code is compiled to a desired release version, while all other tasks (e.g. tests) can use the latest version. This now makes it possible to write tests with Java 25, while keeping application code per module at a specified release version. Shadowed module dependencies (apart from Adventure module) for the plugin module aren't also needed anymore. Since the module now technically "uses" the latest Java version, it accepts compiled classes with differing release versions without any errors.

I currently don't have the means to test this with all platform combinations, but I'd guess running each platform with their minimum supported Java version should suffice. I did decompress the output JAR and inspect a couple of common and platform classes, and their version headers looked correct.