### PR TITLE
Fix and modernize Curseforge Publishing

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Get Download URL
         run: |
           curl 'https://api.github.com/repos/plan-player-analytics/plan/releases/${{ github.event.release.id }}/assets' | jq -r '.[] | {name: .name, url: .browser_download_url} | select(.url | strings | test("Fabric") | not)' > asset.txt
@@ -32,7 +32,7 @@ jobs:
         uses: EndBug/add-and-commit@v10
         with:
           committer_name: GitHub Actions
-          committer_email: 41898282+github-actions[bot]@users.noreply.github.com
+          committer_email: 41898282+github-actions[bot]@users.noreply.github.action
           message: Update versions.txt ${{ github.event.release.name }}
           add: versions.txt
           push: origin HEAD:master
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Get git TAG
         id: tagName
         uses: olegtarasov/get-tag@v2.1
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Download release artifact for upload
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout git repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: ⚙ Get Download URL
@@ -179,7 +179,7 @@ jobs:
           echo "FABRIC_JAR=$(cat name_fabric.txt)" >> $GITHUB_ENV
 
       - name: Modrinth Upload - Plugin 🚀
-        uses: Kira-NT/mc-publish@v3.3
+        uses: Kira-NT/mc-publish@v3
         with:
           modrinth-id: wJQfHhxh
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
@@ -203,7 +203,7 @@ jobs:
           version-type: ${{ github.event.release.prerelease && 'beta' || 'release' }}
 
       - name: Modrinth Upload - Fabric 🚀
-        uses: Kira-NT/mc-publish@v3.3
+        uses: Kira-NT/mc-publish@v3
         with:
           modrinth-id: plan
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -103,34 +103,21 @@ jobs:
           jq -r '.name' asset.txt > name.txt
           wget -i url.txt
           echo "JAR_FILENAME=$(cat name.txt)" >> $GITHUB_ENV
-      - name: Upload release to CurseForge 🚀
-        if: ${{ github.event.release.prerelease == false }}
-        uses: itsmeow/curseforge-upload@master
+      - uses: Kira-NT/mc-publish@v3
         with:
-          token: ${{ secrets.CF_API_TOKEN }}
-          project_id: 508727
-          game_endpoint: minecraft
-          file_path: ${{ env.JAR_FILENAME }}
+          curseforge-id: 394468
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          files: ${{ env.JAR_FILENAME }}
+          name: ${{ github.event.release.name }}
           changelog: ${{ github.event.release.body }}
-          changelog_type: markdown
-          display_name: ${{ github.event.release.name }}
-          game_versions: "2:Java 25,86297:26-2,68441:Fabric"
-          release_type: release
-          relations: fabric-api:requiredDependency,luckperms:optionalDependency
-      - name: Upload prerelease to CurseForge 🚀
-        if: ${{ github.event.release.prerelease == true }}
-        uses: itsmeow/curseforge-upload@master
-        with:
-          token: ${{ secrets.CF_API_TOKEN }}
-          project_id: 508727
-          game_endpoint: minecraft
-          file_path: ${{ env.JAR_FILENAME }}
-          changelog: ${{ github.event.release.body }}
-          changelog_type: markdown
-          display_name: ${{ github.event.release.name }}
-          game_versions: "2:Java 25,86297:26-2,68441:Fabric"
-          release_type: beta
-          relations: fabric-api:requiredDependency,luckperms:optionalDependency
+          loaders: fabric
+          game-versions: |
+            >=26.2
+          version-type: ${{ github.event.release.prerelease && 'beta' || 'release' }}
+          dependencies: |
+            fabric-api(required){curseforge:306612}
+            luckperms(optional){curseforge:431733}
+          java: 25
 
   upload_release_hangar:
     name: Hangar Upload

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -103,10 +103,11 @@ jobs:
           jq -r '.name' asset.txt > name.txt
           wget -i url.txt
           echo "JAR_FILENAME=$(cat name.txt)" >> $GITHUB_ENV
-      - uses: Kira-NT/mc-publish@v3
+      - name: CurseForge Upload - Fabric 🚀
+        uses: Kira-NT/mc-publish@v3
         with:
-          curseforge-id: 394468
-          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          curseforge-id: 508727
+          curseforge-token: ${{ secrets.CF_API_TOKEN }}
           files: ${{ env.JAR_FILENAME }}
           name: ${{ github.event.release.name }}
           changelog: ${{ github.event.release.body }}

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java
@@ -120,7 +120,8 @@ public class Contributors {
             new Contributor("YannicHock", CODE),
             new Contributor("SaolGhra", CODE),
             new Contributor("Jsinco", CODE),
-            new Contributor("julianvdhogen", LANG)
+            new Contributor("julianvdhogen", LANG),
+            new Contributor("Zoriot", CODE),
     };
 
     private Contributors() {


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`

### Description

Fixes Curseforge publishing with changing to mc-publish

Curseforge now needs an environment set which curseforge-upload doesn't support because it's not maintained anymore. Alternatively that could also be merged into Modrinth Upload - Fabric. https://github.com/Kira-NT/mc-publish/issues/170 - i have decided to now do that for now, except the maintainers want it. Would probably make sense. 

Fixes #4752. 