### PR TITLE
✨ Add optional dependency fabric-permissions-api to fabric publish

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -220,3 +220,4 @@ jobs:
           dependencies: |
             P7dR8mSH(required)
             Vebnzrzj(optional)
+            lzVo0Dll(optional)

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -92,34 +92,6 @@ jobs:
           cd Plan
           ./gradlew :plugin:publishToOre
 
-  upload_release_curseforge:
-    name: CurseForge Upload
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download release artifact for upload
-        run: |
-          curl 'https://api.github.com/repos/plan-player-analytics/plan/releases/${{ github.event.release.id }}/assets' | jq -r '.[] | {name: .name, url: .browser_download_url} | select(.url | strings | test("Fabric"))' > asset.txt
-          jq -r '.url' asset.txt > url.txt
-          jq -r '.name' asset.txt > name.txt
-          wget -i url.txt
-          echo "JAR_FILENAME=$(cat name.txt)" >> $GITHUB_ENV
-      - name: CurseForge Upload - Fabric 🚀
-        uses: Kira-NT/mc-publish@v3
-        with:
-          curseforge-id: 508727
-          curseforge-token: ${{ secrets.CF_API_TOKEN }}
-          files: ${{ env.JAR_FILENAME }}
-          name: ${{ github.event.release.name }}
-          changelog: ${{ github.event.release.body }}
-          loaders: fabric
-          game-versions: |
-            >=26.2
-          version-type: ${{ github.event.release.prerelease && 'beta' || 'release' }}
-          dependencies: |
-            fabric-api(required){curseforge:306612}
-            luckperms(optional){curseforge:431733}
-          java: 25
-
   upload_release_hangar:
     name: Hangar Upload
     runs-on: ubuntu-latest
@@ -150,8 +122,8 @@ jobs:
           cd Plan
           ./gradlew :plugin:publishPluginPublicationToHangar
 
-  upload_release_modrinth:
-    name: Modrinth Upload
+  upload_release_modrinth_curseforge:
+    name: Modrinth + Curseforge Upload
     runs-on: ubuntu-latest
     steps:
       - name: Calculate formatted version
@@ -203,11 +175,13 @@ jobs:
             >=1.13
           version-type: ${{ github.event.release.prerelease && 'beta' || 'release' }}
 
-      - name: Modrinth Upload - Fabric 🚀
+      - name: Modrinth + Curseforge Upload - Fabric 🚀
         uses: Kira-NT/mc-publish@v3
         with:
           modrinth-id: plan
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          curseforge-id: 508727
+          curseforge-token: ${{ secrets.CF_API_TOKEN }}
           files: ${{ env.FABRIC_JAR }}
           name: ${{ github.event.release.name }}
           version: ${{ env.FORMATTED_VERSION }}+fabric
@@ -218,6 +192,7 @@ jobs:
             >=26.2
           version-type: ${{ github.event.release.prerelease && 'beta' || 'release' }}
           dependencies: |
-            P7dR8mSH(required)
-            Vebnzrzj(optional)
-            lzVo0Dll(optional)
+            fabric-api(required){modrinth:P7dR8mSH}{curseforge:306612}
+            luckperms(optional){modrinth:Vebnzrzj}{curseforge:431733}
+            fabric-permissions-api-v0(optional){modrinth:lzVo0Dll}
+          java: 25

--- a/Plan/fabric/src/main/resources/fabric.mod.json
+++ b/Plan/fabric/src/main/resources/fabric.mod.json
@@ -19,6 +19,7 @@
     "fabric-api": "*"
   },
   "suggests": {
-    "fabric-permissions-api-v0": "^0.7.0"
+    "fabric-permissions-api-v0": "^0.7.0",
+    "luckperms": "*"
   }
 }


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/plan-player-analytics/Plan/blob/master/CONTRIBUTING.md#writing-a-good-pull-request) to this repository.

- [x] Make sure your name is added to Contributors file `/Plan/common/src/main/java/com/djrapitops/plan/delivery/rendering/html/Contributors.java`

### Description
This adds the [fabric-permissions-api](https://modrinth.com/mod/fabric-permissions-api) to the modrinth publish because using that for permission is recommended over Fabric itself. Not possible for Curseforge because apperently it's not published there. 

This also unifies the dependency from fabric.mod.json with the publishing dependencies. To simplify the workflow mc-publish now publishes the fabric build to modrinth and curseforge at the same time. This also saves some performance / build time. 
