### PR TITLE
Migrate to Jetty 12

### DIFF
--- a/Plan/api/build.gradle
+++ b/Plan/api/build.gradle
@@ -11,7 +11,7 @@ compileJava {
     options.release = 8
 }
 
-def apiVersion = "5.8-R0.1"
+def apiVersion = "5.9-R0.1"
 
 publishing {
     repositories {

--- a/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/AsyncResolver.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/AsyncResolver.java
@@ -1,0 +1,57 @@
+/*
+ *  This file is part of Player Analytics (Plan).
+ *
+ *  Plan is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License v3 as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Plan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Plan. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.djrapitops.plan.delivery.web.resolver;
+
+import com.djrapitops.plan.delivery.web.resolver.request.Request;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+/**
+ * Interface for asynchronously resolving requests of Plan webserver.
+ *
+ * @author AuroraLS3
+ */
+public interface AsyncResolver extends Resolver {
+
+    /**
+     * Implement asynchronous request resolution.
+     *
+     * @param request HTTP request, contains all information necessary to resolve the request.
+     * @return Future of Optional Response or empty if the response should be 404 (not found).
+     * @see Response for return value
+     * @see Request#getPath() for path /example/path etc
+     * @see Request#getQuery() for parameters ?param=value etc
+     */
+    CompletableFuture<Optional<Response>> resolveAsync(Request request);
+
+    @Override
+    default Optional<Response> resolve(Request request) {
+        try {
+            return resolveAsync(request).join();
+        } catch (CompletionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw e;
+        }
+    }
+}

--- a/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/CompositeResolver.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/CompositeResolver.java
@@ -22,6 +22,7 @@ import com.djrapitops.plan.delivery.web.resolver.request.URIPath;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -36,7 +37,7 @@ import java.util.function.Predicate;
  *
  * @author AuroraLS3
  */
-public final class CompositeResolver implements Resolver {
+public final class CompositeResolver implements AsyncResolver {
 
     private final List<String> prefixes;
     private final List<Resolver> resolvers;
@@ -94,9 +95,17 @@ public final class CompositeResolver implements Resolver {
     }
 
     @Override
-    public Optional<Response> resolve(Request request) {
+    public CompletableFuture<Optional<Response>> resolveAsync(Request request) {
         Request forThis = request.omitFirstInPath();
-        return getResolver(forThis.getPath()).flatMap(resolver -> resolver.resolve(forThis));
+        Optional<Resolver> found = getResolver(forThis.getPath());
+        if (!found.isPresent()) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        Resolver resolver = found.get();
+        if (resolver instanceof AsyncResolver) {
+            return ((AsyncResolver) resolver).resolveAsync(forThis);
+        }
+        return CompletableFuture.supplyAsync(() -> resolver.resolve(forThis));
     }
 
     @Override

--- a/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/Response.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/Response.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Represents a response that will be sent over HTTP.
@@ -32,7 +33,7 @@ public final class Response {
 
     final Map<String, String> headers;
     int code = 200;
-    byte[] bytes;
+    CompletableFuture<byte[]> bytes;
     Charset charset; // can be null (raw bytes)
 
     Response() {
@@ -44,11 +45,19 @@ public final class Response {
     }
 
     public byte[] getBytes() {
-        return bytes;
+        return bytes != null ? bytes.join() : new byte[0];
+    }
+
+    public CompletableFuture<byte[]> getBytesAsync() {
+        return bytes != null ? bytes : CompletableFuture.completedFuture(new byte[0]);
     }
 
     public String getAsString() {
-        return new String(bytes, StandardCharsets.UTF_8);
+        return new String(getBytes(), StandardCharsets.UTF_8);
+    }
+
+    public CompletableFuture<String> getAsStringAsync() {
+        return getBytesAsync().thenApply(b -> new String(b, charset != null ? charset : StandardCharsets.UTF_8));
     }
 
     public int getCode() {

--- a/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/ResponseBuilder.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/ResponseBuilder.java
@@ -21,6 +21,7 @@ import com.google.gson.Gson;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
 
 public class ResponseBuilder {
 
@@ -28,17 +29,6 @@ public class ResponseBuilder {
 
     ResponseBuilder() {
         this.response = new Response();
-    }
-
-    /**
-     * Set MIME Type of the Response.
-     *
-     * @param mimeType MIME type of the Response <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">Documentation</a>
-     * @return this builder.
-     * @see MimeType for common MIME types.
-     */
-    public ResponseBuilder setMimeType(String mimeType) {
-        return setHeader("Content-Type", mimeType);
     }
 
     /**
@@ -86,9 +76,15 @@ public class ResponseBuilder {
     }
 
     public ResponseBuilder setContent(byte[] bytes) {
-        response.bytes = bytes;
-        return setHeader("Content-Length", bytes.length)
+        byte[] safeBytes = bytes != null ? bytes : new byte[0];
+        response.bytes = CompletableFuture.completedFuture(safeBytes);
+        return setHeader("Content-Length", safeBytes.length)
                 .setHeader("Accept-Ranges", "bytes"); // Does not compress
+    }
+
+    public ResponseBuilder setContent(CompletableFuture<byte[]> bytesFuture) {
+        response.bytes = bytesFuture != null ? bytesFuture : CompletableFuture.completedFuture(new byte[0]);
+        return this;
     }
 
     public ResponseBuilder setContent(String utf8String) {
@@ -112,6 +108,22 @@ public class ResponseBuilder {
                 .removeHeader("Accept-Ranges"); // Can compress
     }
 
+    public ResponseBuilder setContent(CompletableFuture<String> stringFuture, Charset charset) {
+        if (stringFuture == null) return setContent(new byte[0]);
+        Charset effectiveCharset = charset != null ? charset : StandardCharsets.UTF_8;
+        String mimeType = getMimeType();
+        response.charset = effectiveCharset;
+
+        if (mimeType != null) {
+            String[] parts = mimeType.split(";");
+            if (parts.length == 1) {
+                setMimeType(parts[0] + "; charset=" + effectiveCharset.name().toLowerCase());
+            }
+        }
+        removeHeader("Accept-Ranges");
+        return setContent(stringFuture.thenApply(string -> string == null ? null : string.getBytes(effectiveCharset)));
+    }
+
     /**
      * Set content as serialized JSON object.
      *
@@ -120,11 +132,19 @@ public class ResponseBuilder {
      */
     public ResponseBuilder setJSONContent(Object objectToSerialize) {
         if (objectToSerialize instanceof String) return setJSONContent((String) objectToSerialize);
+        if (objectToSerialize instanceof CompletableFuture) {
+            CompletableFuture<?> future = (CompletableFuture<?>) objectToSerialize;
+            return setJSONContent(future.thenApply(obj -> obj instanceof String ? (String) obj : new Gson().toJson(obj)));
+        }
         return setJSONContent(new Gson().toJson(objectToSerialize));
     }
 
     public ResponseBuilder setJSONContent(String json) {
         return setMimeType(MimeType.JSON).setContent(json);
+    }
+
+    public ResponseBuilder setJSONContent(CompletableFuture<String> jsonFuture) {
+        return setMimeType(MimeType.JSON).setContent(jsonFuture, StandardCharsets.UTF_8);
     }
 
     /**
@@ -137,21 +157,33 @@ public class ResponseBuilder {
      * @see #setMimeType(String) to set MIME-type.
      */
     public Response build() {
-        byte[] content = response.bytes;
-        if(content == null && response.code == 204) {
+        CompletableFuture<byte[]> contentFuture = response.bytes;
+        if (contentFuture == null && response.code == 204) {
             // HTTP Code 204 requires no response, so there is no need to validate it.
             return response;
         }
-        exceptionIf(content == null, "Content not defined for Response");
+        exceptionIf(contentFuture == null, "Content not defined for Response");
         String mimeType = getMimeType();
-        exceptionIf(content.length > 0 && mimeType == null, "MIME Type not defined for Response");
-        exceptionIf(content.length > 0 && mimeType.isEmpty(), "MIME Type empty for Response");
+        boolean hasContent = response.bytes != null && response.bytes.isDone() && response.bytes.join().length > 0;
+        exceptionIf(hasContent && mimeType == null, "MIME Type not defined for Response");
+        exceptionIf(hasContent && mimeType.isEmpty(), "MIME Type empty for Response");
         exceptionIf(response.code < 100 || response.code >= 600, "HTTP Status code out of bounds (" + response.code + ")");
         return response;
     }
 
     private String getMimeType() {
         return response.headers.get("Content-Type");
+    }
+
+    /**
+     * Set MIME Type of the Response.
+     *
+     * @param mimeType MIME type of the Response <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">Documentation</a>
+     * @return this builder.
+     * @see MimeType for common MIME types.
+     */
+    public ResponseBuilder setMimeType(String mimeType) {
+        return setHeader("Content-Type", mimeType);
     }
 
     private void exceptionIf(boolean value, String errorMsg) {

--- a/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
+++ b/Plan/api/src/main/java/com/djrapitops/plan/delivery/web/resolver/request/Request.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Represents a HTTP request to use with {@link Resolver}.
@@ -34,7 +35,7 @@ public final class Request {
     private final URIQuery query;
     private final WebUser user;
     private final Map<String, String> headers;
-    private final byte[] requestBody;
+    private final CompletableFuture<byte[]> requestBody;
     private final String accessIpAddress;
 
     /**
@@ -65,12 +66,27 @@ public final class Request {
      * @param accessIpAddress IP address this request is coming from.
      */
     public Request(String method, URIPath path, URIQuery query, WebUser user, Map<String, String> headers, byte[] requestBody, String accessIpAddress) {
+        this(method, path, query, user, headers, CompletableFuture.completedFuture(requestBody != null ? requestBody : new byte[0]), accessIpAddress);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param method          HTTP method, GET, PUT, POST, etc
+     * @param path            Requested path /example/target
+     * @param query           Request parameters ?param=value etc
+     * @param user            Web user doing the request (if authenticated)
+     * @param headers         Request headers <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers">Documentation</a>
+     * @param requestBody     CompletableFuture of raw body bytes
+     * @param accessIpAddress IP address this request is coming from.
+     */
+    public Request(String method, URIPath path, URIQuery query, WebUser user, Map<String, String> headers, CompletableFuture<byte[]> requestBody, String accessIpAddress) {
         this.method = method;
         this.path = path;
         this.query = query;
         this.user = user;
         this.headers = headers;
-        this.requestBody = requestBody;
+        this.requestBody = requestBody != null ? requestBody : CompletableFuture.completedFuture(new byte[0]);
         this.accessIpAddress = accessIpAddress;
     }
 
@@ -109,7 +125,7 @@ public final class Request {
         }
         this.user = user;
         this.headers = headers;
-        this.requestBody = new byte[0];
+        this.requestBody = CompletableFuture.completedFuture(new byte[0]);
         this.accessIpAddress = accessIpAddress;
     }
 
@@ -142,10 +158,20 @@ public final class Request {
 
     /**
      * Get the raw body, if present.
+     * Blocks until the body is available if fetched asynchronously.
      *
      * @return byte[].
      */
     public byte[] getRequestBody() {
+        return requestBody.join();
+    }
+
+    /**
+     * Get the raw body as a {@link CompletableFuture}.
+     *
+     * @return CompletableFuture of byte[].
+     */
+    public CompletableFuture<byte[]> getRequestBodyAsync() {
         return requestBody;
     }
 
@@ -184,7 +210,7 @@ public final class Request {
                 ", query=" + query +
                 ", user=" + user +
                 ", headers=" + headers +
-                ", body=" + requestBody.length +
+                ", body=" + (requestBody.isDone() && !requestBody.isCompletedExceptionally() ? requestBody.join().length : "async") +
                 '}';
     }
 }

--- a/Plan/build.gradle
+++ b/Plan/build.gradle
@@ -37,7 +37,7 @@ allprojects {
     }
 
     group = "com.djrapitops"
-    version = project.hasProperty("isRelease") ? "$fullVersionFilename" : "5.8-SNAPSHOT"
+    version = project.hasProperty("isRelease") ? "$fullVersionFilename" : "5.9-SNAPSHOT"
 }
 
 subprojects {

--- a/Plan/build.gradle
+++ b/Plan/build.gradle
@@ -69,7 +69,7 @@ subprojects {
         commonsCodecVersion = "1.22.1"
         caffeineVersion = "3.2.4"
         jetbrainsAnnotationsVersion = "26.1.0"
-        jettyVersion = "11.0.26"
+        jettyVersion = "12.1.12"
         mysqlVersion = "9.7.0"
         mariadbVersion = "3.5.10"
         sqliteVersion = "3.42.0.1"

--- a/Plan/build.gradle
+++ b/Plan/build.gradle
@@ -23,7 +23,7 @@ clean {
 allprojects {
     ext {
         majorVersion = "5"
-        minorVersion = "8"
+        minorVersion = "9"
         buildVersion = providers.provider {
             def command = "git rev-list --count HEAD"
             def buildInfo = command.execute().text.trim()

--- a/Plan/bukkit/build.gradle
+++ b/Plan/bukkit/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 }
 
 compileJava {
-    options.release = 11
+    options.release = 17
 }
 
 processResources {

--- a/Plan/bungeecord/build.gradle
+++ b/Plan/bungeecord/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 compileJava {
-    options.release = 11
+    options.release = 17
 }
 
 processResources {

--- a/Plan/common/build.gradle
+++ b/Plan/common/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     api "com.google.code.gson:gson:$gsonVersion"
     api "org.eclipse.jetty:jetty-server:$jettyVersion"
     implementation "org.eclipse.jetty:jetty-alpn-java-server:$jettyVersion"
-    implementation "org.eclipse.jetty.http2:http2-server:$jettyVersion"
+    implementation "org.eclipse.jetty.http2:jetty-http2-server:$jettyVersion"
     implementation "org.jasypt:jasypt:$jasyptVersion:lite"
 
     // Swagger annotations
@@ -119,7 +119,7 @@ dependencies {
 }
 
 compileJava {
-    options.release = 11
+    options.release = 17
 }
 
 test {

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/RequestBodyConverter.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/RequestBodyConverter.java
@@ -36,14 +36,26 @@ public class RequestBodyConverter {
      * @return {@link URIQuery}.
      */
     public static URIQuery formBody(Request request) {
-        return new URIQuery(new String(request.getRequestBody(), StandardCharsets.UTF_8));
+        return formBody(request.getRequestBody());
+    }
+
+    public static URIQuery formBody(byte[] bytes) {
+        return new URIQuery(new String(bytes != null ? bytes : new byte[0], StandardCharsets.UTF_8));
     }
 
     public static <T> T bodyJson(@Untrusted Request request, Gson gson, Class<T> ofType) {
-        return gson.fromJson(new String(request.getRequestBody(), StandardCharsets.UTF_8), ofType);
+        return bodyJson(request.getRequestBody(), gson, ofType);
+    }
+
+    public static <T> T bodyJson(@Untrusted byte[] bytes, Gson gson, Class<T> ofType) {
+        return gson.fromJson(new String(bytes != null ? bytes : new byte[0], StandardCharsets.UTF_8), ofType);
     }
 
     public static <T> T bodyJson(Request request, Gson gson, TypeToken<T> ofType) {
-        return gson.fromJson(new String(request.getRequestBody(), StandardCharsets.UTF_8), ofType.getType());
+        return bodyJson(request.getRequestBody(), gson, ofType);
+    }
+
+    public static <T> T bodyJson(byte[] bytes, Gson gson, TypeToken<T> ofType) {
+        return gson.fromJson(new String(bytes != null ? bytes : new byte[0], StandardCharsets.UTF_8), ofType.getType());
     }
 }

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/ResponseResolver.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/ResponseResolver.java
@@ -18,12 +18,12 @@ package com.djrapitops.plan.delivery.webserver;
 
 import com.djrapitops.plan.delivery.web.ResolverService;
 import com.djrapitops.plan.delivery.web.ResolverSvc;
+import com.djrapitops.plan.delivery.web.resolver.AsyncResolver;
 import com.djrapitops.plan.delivery.web.resolver.NoAuthResolver;
 import com.djrapitops.plan.delivery.web.resolver.Resolver;
 import com.djrapitops.plan.delivery.web.resolver.Response;
 import com.djrapitops.plan.delivery.web.resolver.exception.BadRequestException;
 import com.djrapitops.plan.delivery.web.resolver.exception.MethodNotAllowedException;
-import com.djrapitops.plan.delivery.web.resolver.exception.NotFoundException;
 import com.djrapitops.plan.delivery.web.resolver.request.Request;
 import com.djrapitops.plan.delivery.web.resolver.request.WebUser;
 import com.djrapitops.plan.delivery.webserver.auth.FailReason;
@@ -36,7 +36,6 @@ import com.djrapitops.plan.delivery.webserver.resolver.swagger.SwaggerJsonResolv
 import com.djrapitops.plan.delivery.webserver.resolver.swagger.SwaggerPageResolver;
 import com.djrapitops.plan.exceptions.WebUserAuthException;
 import com.djrapitops.plan.utilities.dev.Untrusted;
-import com.djrapitops.plan.utilities.logging.ErrorContext;
 import com.djrapitops.plan.utilities.logging.ErrorLogger;
 import dagger.Lazy;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
@@ -46,8 +45,11 @@ import io.swagger.v3.oas.annotations.info.License;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
@@ -188,64 +190,87 @@ public class ResponseResolver {
         return request -> Optional.of(response.get());
     }
 
-    public Response getResponse(@Untrusted Request request) {
+    public CompletableFuture<Response> getResponse(@Untrusted Request request) {
         try {
-            return tryToGetResponse(request);
-        } catch (BadRequestException e) {
-            return responseFactory.badRequest(e.getMessage(), request.getPath().asString());
-        } catch (NotFoundException e) {
-            return responseFactory.notFound404(e.getMessage());
-        } catch (MethodNotAllowedException e) {
-            return responseFactory.methodNotAllowed405(e.getMessage(), e.getAllowedMethods());
-        } catch (WebUserAuthException e) {
-            throw e; // Pass along
-        } catch (Exception e) {
-            errorLogger.error(e, ErrorContext.builder().related(request).build());
-            return responseFactory.internalErrorResponse(e, "Failed to get a response");
+            return tryToGetResponse(request)
+                    .exceptionallyCompose(throwable -> handleException(request, throwable));
+        } catch (Exception t) {
+            return handleException(request, t);
         }
     }
 
-    /**
-     * @throws NotFoundException   In some cases when page was not found, not all.
-     * @throws BadRequestException If the request did not have required things.
-     */
-    private Response tryToGetResponse(@Untrusted Request request) {
-        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
-            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS
-            return Response.builder().setStatus(204).build();
-        }
-
-        Optional<WebUser> user = request.getUser();
-
-        List<Resolver> foundResolvers = resolverService.getResolvers(request.getPath().asString());
-        if (foundResolvers.isEmpty()) return responseFactory.pageNotFound404();
-
-        for (Resolver resolver : foundResolvers) {
-            boolean isAuthRequired = webServer.get().isAuthRequired() && resolver.requiresAuth(request);
-            if (isAuthRequired) {
-                if (user.isEmpty()) {
-                    if (webServer.get().isUsingHTTPS()) {
-                        throw new WebUserAuthException(FailReason.NO_USER_PRESENT);
-                    } else {
-                        return responseFactory.forbidden403();
-                    }
-                }
-
-                if (resolver.canAccess(request)) {
-                    Optional<Response> resolved = resolver.resolve(request);
-                    if (resolved.isPresent()) return resolved.get();
-                } else {
-                    if (request.getPath().startsWith("/v1/")) {
-                        return responseFactory.forbidden403Json();
-                    } else {
-                        return responseFactory.forbidden403();
-                    }
-                }
+    public CompletableFuture<Response> handleException(@Untrusted Request request, Throwable exception) {
+        while (exception instanceof CompletionException || exception instanceof java.util.concurrent.ExecutionException) {
+            if (exception.getCause() != null) {
+                exception = exception.getCause();
             } else {
-                Optional<Response> resolved = resolver.resolve(request);
-                if (resolved.isPresent()) return resolved.get();
+                break;
             }
         }
-        return responseFactory.pageNotFound404();
+        if (exception instanceof BadRequestException badRequest) {
+            return CompletableFuture.completedFuture(responseFactory.badRequest(
+                    badRequest.getMessage(), request.getPath().asString()));
+        }
+        if (exception instanceof MethodNotAllowedException notAllowed) {
+            return CompletableFuture.completedFuture(responseFactory.methodNotAllowed405(
+                    notAllowed.getMessage(), notAllowed.getAllowedMethods()));
+        }
+        if (exception instanceof WebUserAuthException authException) {
+            return CompletableFuture.failedFuture(authException); // Pass along
+        }
+        return CompletableFuture.completedFuture(responseFactory.internalErrorResponse(
+                exception, "Failed to get a response"));
+    }
+
+    private CompletableFuture<Response> tryToGetResponse(@Untrusted Request request) {
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS
+            return CompletableFuture.completedFuture(Response.builder().setStatus(204).build());
+        }
+
+
+        List<Resolver> foundResolvers = resolverService.getResolvers(request.getPath().asString());
+        if (foundResolvers.isEmpty()) return CompletableFuture.completedFuture(responseFactory.pageNotFound404());
+        return resolveNext(foundResolvers.iterator(), request);
+    }
+
+    private CompletableFuture<Response> resolveNext(Iterator<Resolver> iterator, @Untrusted Request request) {
+        if (!iterator.hasNext()) {
+            return CompletableFuture.completedFuture(responseFactory.pageNotFound404());
+        }
+
+        Resolver resolver = iterator.next();
+        Optional<WebUser> user = request.getUser();
+        boolean isAuthRequired = webServer.get().isAuthRequired() && resolver.requiresAuth(request);
+        if (isAuthRequired) {
+            if (user.isEmpty()) {
+                if (webServer.get().isUsingHTTPS()) {
+                    throw new WebUserAuthException(FailReason.NO_USER_PRESENT);
+                } else {
+                    return CompletableFuture.completedFuture(responseFactory.forbidden403());
+                }
+            }
+
+            if (!resolver.canAccess(request)) {
+                if (request.getPath().startsWith("/v1/")) {
+                    return CompletableFuture.completedFuture(responseFactory.forbidden403Json());
+                } else {
+                    return CompletableFuture.completedFuture(responseFactory.forbidden403());
+                }
+            }
+        }
+
+        CompletableFuture<Optional<Response>> futureResponse;
+        try {
+            futureResponse = resolver instanceof AsyncResolver asyncResolver
+                    ? asyncResolver.resolveAsync(request)
+                    : CompletableFuture.supplyAsync(() -> resolver.resolve(request));
+        } catch (Exception t) { // Some exceptions may be thrown sync based on the request.
+            futureResponse = CompletableFuture.failedFuture(t);
+        }
+        return futureResponse.thenCompose(gotResponse ->
+                gotResponse.map(CompletableFuture::completedFuture) // try next resolver
+                        .orElseGet(() -> resolveNext(iterator, request))
+        );
     }
 }

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyInternalRequest.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyInternalRequest.java
@@ -23,62 +23,60 @@ import com.djrapitops.plan.delivery.webserver.auth.AuthenticationExtractor;
 import com.djrapitops.plan.delivery.webserver.auth.Cookie;
 import com.djrapitops.plan.delivery.webserver.configuration.WebserverConfiguration;
 import com.djrapitops.plan.utilities.dev.Untrusted;
-import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.text.TextStringBuilder;
+import org.eclipse.jetty.http.HttpCookie;
+import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Request;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Spliterators;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 public class JettyInternalRequest implements InternalRequest {
 
-    private final Request baseRequest;
-    private final HttpServletRequest request;
+    private final Request request;
     private final WebserverConfiguration webserverConfiguration;
     private final AuthenticationExtractor authenticationExtractor;
 
-    public JettyInternalRequest(Request baseRequest, HttpServletRequest request, WebserverConfiguration webserverConfiguration, AuthenticationExtractor authenticationExtractor) {
-        this.baseRequest = baseRequest;
+    public JettyInternalRequest(Request request, WebserverConfiguration webserverConfiguration, AuthenticationExtractor authenticationExtractor) {
         this.request = request;
         this.webserverConfiguration = webserverConfiguration;
         this.authenticationExtractor = authenticationExtractor;
     }
 
     @Override
-    public long getTimestamp() {return baseRequest.getTimeStamp();}
+    public long getTimestamp() {return Request.getTimeStamp(request);}
 
     @Override
-    public String getMethod() {return baseRequest.getMethod();}
+    public String getMethod() {return request.getMethod();}
 
     @Override
     public String getAccessAddressFromSocketIp() {
-        return baseRequest.getRemoteAddr();
+        return Request.getRemoteAddr(request);
     }
 
     @Override
     public String getAccessAddressFromHeader() {
-        String header = baseRequest.getHeader(HttpHeader.X_FORWARDED_FOR.asString());
+        String header = getHeader(HttpHeader.X_FORWARDED_FOR);
         if (header != null && header.contains(",")) {
             return header.split(",")[0].trim();
         }
         return header;
     }
 
+    private String getHeader(HttpHeader headerName) {
+        return request.getHeaders().get(headerName);
+    }
+
     @Override
     public com.djrapitops.plan.delivery.web.resolver.request.Request toRequest(@Untrusted String accessAddress) {
-        String requestMethod = baseRequest.getMethod();
-        @Untrusted URIPath path = new URIPath(baseRequest.getHttpURI().getDecodedPath());
-        @Untrusted URIQuery query = new URIQuery(baseRequest.getHttpURI().getQuery());
+        String requestMethod = request.getMethod();
+        @Untrusted URIPath path = new URIPath(request.getHttpURI().getDecodedPath());
+        @Untrusted URIQuery query = new URIQuery(request.getHttpURI().getQuery());
         @Untrusted byte[] requestBody = readRequestBody();
         WebUser user = getWebUser(webserverConfiguration, authenticationExtractor, accessAddress);
         @Untrusted Map<String, String> headers = getRequestHeaders();
@@ -87,23 +85,14 @@ public class JettyInternalRequest implements InternalRequest {
 
     @Override
     public Map<String, String> getRequestHeaders() {
-        return streamHeaderNames()
-                .collect(Collectors.toMap(Function.identity(), baseRequest::getHeader,
+        return request.getHeaders().stream()
+                .collect(Collectors.toMap(HttpField::getName, HttpField::getValue,
                         (one, two) -> one + ';' + two));
     }
 
-    private Stream<String> streamHeaderNames() {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(baseRequest.getHeaderNames().asIterator(), 0), false);
-    }
-
     private byte[] readRequestBody() {
-        try (BufferedReader reader = request.getReader();
-             ByteArrayOutputStream buf = new ByteArrayOutputStream(512)) {
-            int b;
-            while ((b = reader.read()) != -1) {
-                buf.write((byte) b);
-            }
-            return buf.toByteArray();
+        try (InputStream reader = Content.Source.asInputStream(request)) {
+            return reader.readAllBytes();
         } catch (IOException ignored) {
             // requestBody stays empty
             return new byte[0];
@@ -112,37 +101,30 @@ public class JettyInternalRequest implements InternalRequest {
 
     @Override
     public List<Cookie> getCookies() {
-        @Untrusted List<String> textCookies = getCookieHeaders();
+        @Untrusted List<HttpCookie> jettyCookies = Request.getCookies(request);
         List<Cookie> cookies = new ArrayList<>();
-        if (!textCookies.isEmpty()) {
-            String[] separated = new TextStringBuilder().appendWithSeparators(textCookies, ";").get().split(";");
-            for (String textCookie : separated) {
-                cookies.add(new Cookie(textCookie.trim()));
+        if (!jettyCookies.isEmpty()) {
+            for (HttpCookie cookie : jettyCookies) {
+                cookies.add(new Cookie(cookie.getName(), cookie.getValue()));
             }
         }
         return cookies;
     }
 
-    private List<String> getCookieHeaders() {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(request.getHeaders(HttpHeader.COOKIE.asString()).asIterator(), 0), false)
-                .collect(Collectors.toList());
-    }
-
     @Override
     public String getRequestedURIString() {
-        return baseRequest.getRequestURI();
+        return request.getHttpURI().getPath();
     }
 
     @Override
     public String getRequestedPathAndQuery() {
-        return baseRequest.getHttpURI().getDecodedPath() + baseRequest.getHttpURI().getQuery();
+        return request.getHttpURI().getDecodedPath() + request.getHttpURI().getQuery();
     }
 
     @Override
     public String toString() {
         return "JettyInternalRequest{" +
-                "baseRequest=" + baseRequest +
-                ", request=" + request +
+                "request=" + request +
                 ", webserverConfiguration=" + webserverConfiguration +
                 ", authenticationExtractor=" + authenticationExtractor +
                 '}';

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyInternalRequest.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyInternalRequest.java
@@ -28,12 +28,12 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.util.Promise;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class JettyInternalRequest implements InternalRequest {
@@ -77,7 +77,7 @@ public class JettyInternalRequest implements InternalRequest {
         String requestMethod = request.getMethod();
         @Untrusted URIPath path = new URIPath(request.getHttpURI().getDecodedPath());
         @Untrusted URIQuery query = new URIQuery(request.getHttpURI().getQuery());
-        @Untrusted byte[] requestBody = readRequestBody();
+        CompletableFuture<byte[]> requestBody = readRequestBodyAsync();
         WebUser user = getWebUser(webserverConfiguration, authenticationExtractor, accessAddress);
         @Untrusted Map<String, String> headers = getRequestHeaders();
         return new com.djrapitops.plan.delivery.web.resolver.request.Request(requestMethod, path, query, user, headers, requestBody, accessAddress);
@@ -90,13 +90,20 @@ public class JettyInternalRequest implements InternalRequest {
                         (one, two) -> one + ';' + two));
     }
 
-    private byte[] readRequestBody() {
-        try (InputStream reader = Content.Source.asInputStream(request)) {
-            return reader.readAllBytes();
-        } catch (IOException ignored) {
-            // requestBody stays empty
-            return new byte[0];
-        }
+    private CompletableFuture<byte[]> readRequestBodyAsync() {
+        CompletableFuture<byte[]> future = new CompletableFuture<>();
+        Content.Source.asByteArrayAsync(request, Integer.MAX_VALUE, new Promise.Invocable<>() {
+            @Override
+            public void succeeded(byte[] result) {
+                future.complete(result != null ? result : new byte[0]);
+            }
+
+            @Override
+            public void failed(Throwable x) {
+                future.complete(new byte[0]);
+            }
+        });
+        return future;
     }
 
     @Override

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyRequestHandler.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyRequestHandler.java
@@ -24,19 +24,16 @@ import com.djrapitops.plan.settings.config.PlanConfig;
 import com.djrapitops.plan.settings.config.paths.PluginSettings;
 import com.djrapitops.plan.utilities.logging.ErrorContext;
 import com.djrapitops.plan.utilities.logging.ErrorLogger;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import net.playeranalytics.plugin.server.PluginLogger;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.util.Callback;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.io.IOException;
 
 @Singleton
-public class JettyRequestHandler extends AbstractHandler {
+public class JettyRequestHandler extends Handler.Abstract {
 
     private final WebserverConfiguration webserverConfiguration;
     private final AuthenticationExtractor authenticationExtractor;
@@ -58,21 +55,23 @@ public class JettyRequestHandler extends AbstractHandler {
     }
 
     @Override
-    public void handle(String target, Request baseRequest, HttpServletRequest servletRequest, HttpServletResponse servletResponse) throws IOException, ServletException {
+    public boolean handle(Request request, org.eclipse.jetty.server.Response jettyResponse, Callback callback) throws Exception {
         try {
-            InternalRequest internalRequest = new JettyInternalRequest(baseRequest, servletRequest, webserverConfiguration, authenticationExtractor);
+            InternalRequest internalRequest = new JettyInternalRequest(request, webserverConfiguration, authenticationExtractor);
             Response response = requestHandler.getResponse(internalRequest);
-            new JettyResponseSender(response, servletRequest, servletResponse, addresses).send();
-            baseRequest.setHandled(true);
+            new JettyResponseSender(response, request, jettyResponse, addresses).send();
+            callback.succeeded();
+            return true;
         } catch (Exception e) {
             if (config.isTrue(PluginSettings.DEV_MODE)) {
                 logger.warn("THIS ERROR IS ONLY LOGGED IN DEV MODE:");
                 errorLogger.warn(e, ErrorContext.builder()
                         .whatToDo("THIS ERROR IS ONLY LOGGED IN DEV MODE")
-                        .related(baseRequest.getMethod(), baseRequest.getRemoteAddr(), target, baseRequest.getRequestURI())
+                        .related(request.getMethod(), Request.getRemoteAddr(request), request.getHttpURI().getPath())
                         .build());
             }
+            callback.failed(e);
+            throw e;
         }
-
     }
 }

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyRequestHandler.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyRequestHandler.java
@@ -16,10 +16,10 @@
  */
 package com.djrapitops.plan.delivery.webserver.http;
 
-import com.djrapitops.plan.delivery.web.resolver.Response;
 import com.djrapitops.plan.delivery.webserver.Addresses;
 import com.djrapitops.plan.delivery.webserver.auth.AuthenticationExtractor;
 import com.djrapitops.plan.delivery.webserver.configuration.WebserverConfiguration;
+import com.djrapitops.plan.processing.Processing;
 import com.djrapitops.plan.settings.config.PlanConfig;
 import com.djrapitops.plan.settings.config.paths.PluginSettings;
 import com.djrapitops.plan.utilities.logging.ErrorContext;
@@ -31,6 +31,7 @@ import org.eclipse.jetty.util.Callback;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 public class JettyRequestHandler extends Handler.Abstract {
@@ -39,16 +40,18 @@ public class JettyRequestHandler extends Handler.Abstract {
     private final AuthenticationExtractor authenticationExtractor;
     private final Addresses addresses;
     private final RequestHandler requestHandler;
+    private final Processing processing;
     private final PlanConfig config;
     private final PluginLogger logger;
     private final ErrorLogger errorLogger;
 
     @Inject
-    public JettyRequestHandler(WebserverConfiguration webserverConfiguration, AuthenticationExtractor authenticationExtractor, Addresses addresses, RequestHandler requestHandler, PlanConfig config, PluginLogger logger, ErrorLogger errorLogger) {
+    public JettyRequestHandler(WebserverConfiguration webserverConfiguration, AuthenticationExtractor authenticationExtractor, Addresses addresses, RequestHandler requestHandler, Processing processing, PlanConfig config, PluginLogger logger, ErrorLogger errorLogger) {
         this.webserverConfiguration = webserverConfiguration;
         this.authenticationExtractor = authenticationExtractor;
         this.addresses = addresses;
         this.requestHandler = requestHandler;
+        this.processing = processing;
         this.config = config;
         this.logger = logger;
         this.errorLogger = errorLogger;
@@ -58,20 +61,32 @@ public class JettyRequestHandler extends Handler.Abstract {
     public boolean handle(Request request, org.eclipse.jetty.server.Response jettyResponse, Callback callback) throws Exception {
         try {
             InternalRequest internalRequest = new JettyInternalRequest(request, webserverConfiguration, authenticationExtractor);
-            Response response = requestHandler.getResponse(internalRequest);
-            new JettyResponseSender(response, request, jettyResponse, addresses).send();
-            callback.succeeded();
+            CompletableFuture.supplyAsync(() -> requestHandler.getResponse(internalRequest), processing.getNonCriticalExecutor())
+                    .thenApply(response -> new JettyResponseSender(response, request, jettyResponse, addresses))
+                    .thenCompose(JettyResponseSender::sendAsync)
+                    .whenComplete((result, throwable) -> {
+                        if (throwable != null) {
+                            logError(request, throwable);
+                            callback.failed(throwable);
+                        } else {
+                            callback.succeeded();
+                        }
+                    });
             return true;
         } catch (Exception e) {
-            if (config.isTrue(PluginSettings.DEV_MODE)) {
-                logger.warn("THIS ERROR IS ONLY LOGGED IN DEV MODE:");
-                errorLogger.warn(e, ErrorContext.builder()
-                        .whatToDo("THIS ERROR IS ONLY LOGGED IN DEV MODE")
-                        .related(request.getMethod(), Request.getRemoteAddr(request), request.getHttpURI().getPath())
-                        .build());
-            }
+            logError(request, e);
             callback.failed(e);
             throw e;
+        }
+    }
+
+    private void logError(Request request, Throwable e) {
+        if (config.isTrue(PluginSettings.DEV_MODE)) {
+            logger.warn("THIS ERROR IS ONLY LOGGED IN DEV MODE:");
+            errorLogger.warn(e, ErrorContext.builder()
+                    .whatToDo("THIS ERROR IS ONLY LOGGED IN DEV MODE")
+                    .related(request.getMethod(), Request.getRemoteAddr(request), request.getHttpURI().getPath())
+                    .build());
         }
     }
 }

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyRequestHandler.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyRequestHandler.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.util.Callback;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 @Singleton
 public class JettyRequestHandler extends Handler.Abstract {
@@ -62,6 +63,7 @@ public class JettyRequestHandler extends Handler.Abstract {
         try {
             InternalRequest internalRequest = new JettyInternalRequest(request, webserverConfiguration, authenticationExtractor);
             CompletableFuture.supplyAsync(() -> requestHandler.getResponse(internalRequest), processing.getNonCriticalExecutor())
+                    .thenCompose(Function.identity())
                     .thenApply(response -> new JettyResponseSender(response, request, jettyResponse, addresses))
                     .thenCompose(JettyResponseSender::sendAsync)
                     .whenComplete((result, throwable) -> {

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyResponseSender.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyResponseSender.java
@@ -17,12 +17,12 @@
 package com.djrapitops.plan.delivery.webserver.http;
 
 import com.djrapitops.plan.delivery.web.resolver.MimeType;
-import com.djrapitops.plan.delivery.web.resolver.Response;
 import com.djrapitops.plan.delivery.webserver.Addresses;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.Strings;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -33,20 +33,20 @@ import java.util.zip.GZIPOutputStream;
 
 public class JettyResponseSender {
 
-    private final Response response;
-    private final HttpServletRequest servletRequest;
-    private final HttpServletResponse servletResponse;
+    private final com.djrapitops.plan.delivery.web.resolver.Response response;
+    private final Request jettyRequest;
+    private final Response jettyResponse;
     private final Addresses addresses;
 
-    public JettyResponseSender(Response response, HttpServletRequest servletRequest, HttpServletResponse servletResponse, Addresses addresses) {
+    public JettyResponseSender(com.djrapitops.plan.delivery.web.resolver.Response response, Request jettyRequest, Response jettyResponse, Addresses addresses) {
         this.response = response;
-        this.servletRequest = servletRequest;
-        this.servletResponse = servletResponse;
+        this.jettyRequest = jettyRequest;
+        this.jettyResponse = jettyResponse;
         this.addresses = addresses;
     }
 
     public void send() throws IOException {
-        if ("HEAD".equals(servletRequest.getMethod()) || response.getCode() == 204 || response.getCode() == 304) {
+        if ("HEAD".equals(jettyRequest.getMethod()) || response.getCode() == 204 || response.getCode() == 304) {
             setResponseHeaders();
             sendHeadResponse();
         } else if (canGzip()) {
@@ -58,17 +58,16 @@ public class JettyResponseSender {
     }
 
     private boolean canGzip() {
-        String method = servletRequest.getMethod();
+        String method = jettyRequest.getMethod();
         String mimeType = response.getHeaders().get(HttpHeader.CONTENT_TYPE.asString());
         return "GET".equals(method) && Strings.CS.containsAny(mimeType, MimeType.HTML, MimeType.CSS, MimeType.JS, MimeType.JSON, "text/plain");
     }
 
     public void sendHeadResponse() throws IOException {
-        try {
-            response.getHeaders().remove(HttpHeader.CONTENT_LENGTH.asString());
-            beginSend();
-        } finally {
-            servletResponse.getOutputStream().close();
+        response.getHeaders().remove(HttpHeader.CONTENT_LENGTH.asString());
+        beginSend();
+        try (OutputStream out = Content.Sink.asOutputStream(jettyResponse)) {
+            send(out, new byte[0]);
         }
     }
 
@@ -77,7 +76,7 @@ public class JettyResponseSender {
         correctRedirect(responseHeaders);
 
         for (Map.Entry<String, String> header : responseHeaders.entrySet()) {
-            servletResponse.setHeader(header.getKey(), header.getValue());
+            jettyResponse.getHeaders().add(header.getKey(), header.getValue());
         }
     }
 
@@ -93,12 +92,13 @@ public class JettyResponseSender {
         response.getHeaders().remove(HttpHeader.ACCEPT_RANGES.asString());
         response.getHeaders().put(HttpHeader.CONTENT_ENCODING.asString(), "gzip");
 
+
         byte[] gzipped = gzip();
-        try (OutputStream out = servletResponse.getOutputStream()) {
+        try (OutputStream out = Content.Sink.asOutputStream(jettyResponse)) {
             response.getHeaders().put(HttpHeader.CONTENT_LENGTH.asString(), String.valueOf(gzipped.length));
             setResponseHeaders();
 
-            servletResponse.setStatus(response.getCode());
+            jettyResponse.setStatus(response.getCode());
 
             send(out, gzipped);
         }
@@ -121,18 +121,18 @@ public class JettyResponseSender {
                 || "0".equals(length)
                 || response.getCode() == 204
                 || response.getCode() == 304
-                || "HEAD".equals(servletRequest.getMethod())
+                || "HEAD".equals(jettyRequest.getMethod())
         ) {
-            servletResponse.setHeader(HttpHeader.CONTENT_LENGTH.asString(), null);
+            jettyResponse.getHeaders().remove(HttpHeader.CONTENT_LENGTH.asString());
         }
         // Return a content length of -1 for HTTP code 204 (No content)
         // and HEAD requests to avoid warning messages.
-        servletResponse.setStatus(response.getCode());
+        jettyResponse.setStatus(response.getCode());
     }
 
     private void sendRawBytes() throws IOException {
         beginSend();
-        try (OutputStream out = servletResponse.getOutputStream()) {
+        try (OutputStream out = Content.Sink.asOutputStream(jettyResponse)) {
             send(out);
         }
     }

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyResponseSender.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyResponseSender.java
@@ -20,15 +20,16 @@ import com.djrapitops.plan.delivery.web.resolver.MimeType;
 import com.djrapitops.plan.delivery.webserver.Addresses;
 import org.apache.commons.lang3.Strings;
 import org.eclipse.jetty.http.HttpHeader;
-import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.zip.GZIPOutputStream;
 
 public class JettyResponseSender {
@@ -46,14 +47,25 @@ public class JettyResponseSender {
     }
 
     public void send() throws IOException {
+        try {
+            sendAsync().join();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            }
+            throw new IOException(e.getCause() != null ? e.getCause() : e);
+        }
+    }
+
+    public CompletableFuture<Void> sendAsync() {
         if ("HEAD".equals(jettyRequest.getMethod()) || response.getCode() == 204 || response.getCode() == 304) {
             setResponseHeaders();
-            sendHeadResponse();
+            return sendHeadResponse();
         } else if (canGzip()) {
-            sendCompressed();
+            return sendCompressed();
         } else {
             setResponseHeaders();
-            sendRawBytes();
+            return sendRawBytes();
         }
     }
 
@@ -63,12 +75,12 @@ public class JettyResponseSender {
         return "GET".equals(method) && Strings.CS.containsAny(mimeType, MimeType.HTML, MimeType.CSS, MimeType.JS, MimeType.JSON, "text/plain");
     }
 
-    public void sendHeadResponse() throws IOException {
+    public CompletableFuture<Void> sendHeadResponse() {
         response.getHeaders().remove(HttpHeader.CONTENT_LENGTH.asString());
         beginSend();
-        try (OutputStream out = Content.Sink.asOutputStream(jettyResponse)) {
-            send(out, new byte[0]);
-        }
+        Callback.Completable completable = new Callback.Completable();
+        jettyResponse.write(true, ByteBuffer.wrap(new byte[0]), completable);
+        return completable;
     }
 
     private void setResponseHeaders() {
@@ -88,27 +100,34 @@ public class JettyResponseSender {
         }
     }
 
-    private void sendCompressed() throws IOException {
-        response.getHeaders().remove(HttpHeader.ACCEPT_RANGES.asString());
-        response.getHeaders().put(HttpHeader.CONTENT_ENCODING.asString(), "gzip");
+    private CompletableFuture<Void> sendCompressed() {
+        return response.getBytesAsync().thenCompose(rawBytes -> {
+            try {
+                response.getHeaders().remove(HttpHeader.ACCEPT_RANGES.asString());
+                response.getHeaders().put(HttpHeader.CONTENT_ENCODING.asString(), "gzip");
 
+                byte[] gzipped = gzip(rawBytes);
+                response.getHeaders().put(HttpHeader.CONTENT_LENGTH.asString(), String.valueOf(gzipped.length));
+                setResponseHeaders();
 
-        byte[] gzipped = gzip();
-        try (OutputStream out = Content.Sink.asOutputStream(jettyResponse)) {
-            response.getHeaders().put(HttpHeader.CONTENT_LENGTH.asString(), String.valueOf(gzipped.length));
-            setResponseHeaders();
+                jettyResponse.setStatus(response.getCode());
 
-            jettyResponse.setStatus(response.getCode());
-
-            send(out, gzipped);
-        }
+                Callback.Completable completable = new Callback.Completable();
+                jettyResponse.write(true, ByteBuffer.wrap(gzipped), completable);
+                return completable;
+            } catch (IOException e) {
+                CompletableFuture<Void> failed = new CompletableFuture<>();
+                failed.completeExceptionally(e);
+                return failed;
+            }
+        });
     }
 
-    private byte[] gzip() throws IOException {
+    private byte[] gzip(byte[] bytes) throws IOException {
         try (ByteArrayOutputStream bufferStream = new ByteArrayOutputStream();
              GZIPOutputStream gzipStream = new GZIPOutputStream(bufferStream)
         ) {
-            gzipStream.write(response.getBytes());
+            gzipStream.write(bytes);
             gzipStream.finish();
             gzipStream.flush();
             return bufferStream.toByteArray();
@@ -130,26 +149,12 @@ public class JettyResponseSender {
         jettyResponse.setStatus(response.getCode());
     }
 
-    private void sendRawBytes() throws IOException {
+    private CompletableFuture<Void> sendRawBytes() {
         beginSend();
-        try (OutputStream out = Content.Sink.asOutputStream(jettyResponse)) {
-            send(out);
-        }
-    }
-
-    private void send(OutputStream out) throws IOException {
-        send(out, response.getBytes());
-    }
-
-    private void send(OutputStream out, byte[] bytes) throws IOException {
-        try (
-                ByteArrayInputStream bis = new ByteArrayInputStream(bytes)
-        ) {
-            byte[] buffer = new byte[2048];
-            int count;
-            while ((count = bis.read(buffer)) != -1) {
-                out.write(buffer, 0, count);
-            }
-        }
+        return response.getBytesAsync().thenCompose(bytes -> {
+            Callback.Completable completable = new Callback.Completable();
+            jettyResponse.write(true, ByteBuffer.wrap(bytes), completable);
+            return completable;
+        });
     }
 }

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyWebserver.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyWebserver.java
@@ -76,76 +76,80 @@ public class JettyWebserver implements WebServer {
             return;
         }
 
-        webserver = new Server();
-        webserver.setStopAtShutdown(true);
+        // Jetty loads its services from thread context classloader, but thread context doesn't have all Jetty classes.
+        // Because of this we swap to plugin classloader before any operations so that the loading succeeds.
+        ThreadContextClassLoaderSwap.performOperation(getClass().getClassLoader(), () -> {
+            webserver = new Server();
+            webserver.setStopAtShutdown(true);
 
-        this.port = webserverConfiguration.getPort();
+            this.port = webserverConfiguration.getPort();
 
-        HttpConfiguration configuration = new HttpConfiguration();
-        Optional<SslContextFactory.Server> sslContext = getSslContextFactory();
-        sslContext.ifPresent(ssl -> {
-            configuration.setSecureScheme("https");
-            configuration.setSecurePort(port);
+            HttpConfiguration configuration = new HttpConfiguration();
+            Optional<SslContextFactory.Server> sslContext = getSslContextFactory();
+            sslContext.ifPresent(ssl -> {
+                configuration.setSecureScheme("https");
+                configuration.setSecurePort(port);
 
-            SecureRequestCustomizer serverNameIdentifierCheckSkipper = new SecureRequestCustomizer();
-            serverNameIdentifierCheckSkipper.setSniHostCheck(false);
-            serverNameIdentifierCheckSkipper.setSniRequired(false);
-            configuration.addCustomizer(serverNameIdentifierCheckSkipper);
+                SecureRequestCustomizer serverNameIdentifierCheckSkipper = new SecureRequestCustomizer();
+                serverNameIdentifierCheckSkipper.setSniHostCheck(false);
+                serverNameIdentifierCheckSkipper.setSniRequired(false);
+                configuration.addCustomizer(serverNameIdentifierCheckSkipper);
 
-            usingHttps = true;
-        });
+                usingHttps = true;
+            });
 
-        HttpConnectionFactory httpConnector = new HttpConnectionFactory(configuration);
+            HttpConnectionFactory httpConnector = new HttpConnectionFactory(configuration);
 
-        HTTP2CServerConnectionFactory http2CConnector = new HTTP2CServerConnectionFactory(configuration);
-        http2CConnector.setConnectProtocolEnabled(true);
+            HTTP2CServerConnectionFactory http2CConnector = new HTTP2CServerConnectionFactory(configuration);
+            http2CConnector.setConnectProtocolEnabled(true);
 
 
-        ServerConnector connector = sslContext
-                .map(sslContextFactory -> {
-                    HTTP2ServerConnectionFactory http2Connector = new HTTP2ServerConnectionFactory(configuration);
-                    http2Connector.setConnectProtocolEnabled(true);
-                    ALPNServerConnectionFactory alpn = getAlpnServerConnectionFactory(httpConnector.getProtocol());
+            ServerConnector connector = sslContext
+                    .map(sslContextFactory -> {
+                        HTTP2ServerConnectionFactory http2Connector = new HTTP2ServerConnectionFactory(configuration);
+                        http2Connector.setConnectProtocolEnabled(true);
+                        ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory("h2", "h2c", "http/1.1");
+                        alpn.setDefaultProtocol(httpConnector.getProtocol());
+                        return new ServerConnector(webserver, sslContextFactory, alpn, httpConnector, http2Connector, http2CConnector);
+                    })
+                    .orElseGet(() -> {
+                        if (webserverConfiguration.isProxyModeHttps()) {
+                            webserverLogMessages.authenticationUsingProxy();
+                        } else {
+                            webserverLogMessages.authenticationNotPossible();
+                        }
+                        return new ServerConnector(webserver, httpConnector, http2CConnector);
+                    });
 
-                    return new ServerConnector(webserver, sslContextFactory, alpn, httpConnector, http2Connector, http2CConnector);
-                })
-                .orElseGet(() -> {
-                    if (webserverConfiguration.isProxyModeHttps()) {
-                        webserverLogMessages.authenticationUsingProxy();
-                    } else {
-                        webserverLogMessages.authenticationNotPossible();
-                    }
-                    return new ServerConnector(webserver, httpConnector, http2CConnector);
-                });
+            connector.setPort(port);
+            String internalIP = webserverConfiguration.getInternalIP();
+            connector.setHost(internalIP);
+            webserver.addConnector(connector);
 
-        connector.setPort(port);
-        String internalIP = webserverConfiguration.getInternalIP();
-        connector.setHost(internalIP);
-        webserver.addConnector(connector);
+            webserver.setHandler(jettyRequestHandler);
 
-        webserver.setHandler(jettyRequestHandler);
-
-        String startFailure = "Failed to start Jetty webserver: ";
-        try {
-            webserver.start();
-        } catch (IOException e) {
-            if (e.getMessage().contains("Failed to bind")) {
-                boolean defaultInternalIp = "0.0.0.0".equals(internalIP);
-                String causeHelp = defaultInternalIp ? ", is the port (" + port + ") in use?" : ", is the Internal_IP (" + internalIP + ") invalid? (Use 0.0.0.0 for automatic)";
-                throw new EnableException(startFailure + e.getMessage().replace("0.0.0.0", "") + causeHelp, e);
-            } else {
+            String startFailure = "Failed to start Jetty webserver: ";
+            try {
+                webserver.start();
+            } catch (IOException e) {
+                if (e.getMessage().contains("Failed to bind")) {
+                    boolean defaultInternalIp = "0.0.0.0".equals(internalIP);
+                    String causeHelp = defaultInternalIp ? ", is the port (" + port + ") in use?" : ", is the Internal_IP (" + internalIP + ") invalid? (Use 0.0.0.0 for automatic)";
+                    throw new EnableException(startFailure + e.getMessage().replace("0.0.0.0", "") + causeHelp, e);
+                } else {
+                    throw new EnableException(startFailure + e.toString(), e);
+                }
+            } catch (Exception e) {
                 throw new EnableException(startFailure + e.toString(), e);
             }
-        } catch (Exception e) {
-            throw new EnableException(startFailure + e.toString(), e);
-        }
 
-        webserverLogMessages.infoWebserverEnabled(getPort());
-        sslContext.map(SslContextFactory::getKeyStore).ifPresent(this::logCertificateExpiryInformation);
+            webserverLogMessages.infoWebserverEnabled(getPort());
+            sslContext.map(SslContextFactory::getKeyStore).ifPresent(this::logCertificateExpiryInformation);
 
-        responseResolver.registerPages();
+            responseResolver.registerPages();
 
-        webserverConfiguration.getAllowedIpList().prepare();
+            webserverConfiguration.getAllowedIpList().prepare();
+        });
     }
 
     private void logCertificateExpiryInformation(KeyStore keyStore) {

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyWebserver.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/JettyWebserver.java
@@ -168,22 +168,6 @@ public class JettyWebserver implements WebServer {
         }
     }
 
-    private ALPNServerConnectionFactory getAlpnServerConnectionFactory(String protocol) {
-        ClassLoader pluginClassLoader = getClass().getClassLoader();
-        return ThreadContextClassLoaderSwap.performOperation(pluginClassLoader, () -> {
-            try {
-                Class.forName("org.eclipse.jetty.alpn.java.server.JDK9ServerALPNProcessor");
-                // ALPN is protocol upgrade protocol required for upgrading http 1.1 connections to 2
-                ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory("h2", "h2c", "http/1.1");
-                alpn.setDefaultProtocol(protocol);
-                return alpn;
-            } catch (IllegalStateException | ClassNotFoundException ignored) {
-                logger.warn("JDK9ServerALPNProcessor not found. ALPN (HTTP/2 upgrade protocol) is not available.");
-                return null;
-            }
-        });
-    }
-
     private Optional<SslContextFactory.Server> getSslContextFactory() {
         if (webserverConfiguration.isProxyModeHttps()) {
             return Optional.empty();

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/RequestHandler.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/http/RequestHandler.java
@@ -31,7 +31,9 @@ import org.eclipse.jetty.http.HttpHeader;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 public class RequestHandler {
@@ -55,61 +57,87 @@ public class RequestHandler {
         rateLimitGuard = new RateLimitGuard();
     }
 
-    public Response getResponse(InternalRequest internalRequest) {
+    public CompletableFuture<Response> getResponse(InternalRequest internalRequest) {
         @Untrusted(reason = "from header") String accessAddress = internalRequest.getAccessAddress(webserverConfiguration);
         @Untrusted String requestedPath = internalRequest.getRequestedPathAndQuery();
 
         boolean blocked = false;
-        Response response;
+        CompletableFuture<Response> response;
         @Untrusted Request request = null;
         if (bruteForceGuard.shouldPreventRequest(accessAddress)) {
-            response = responseFactory.failedLoginAttempts403();
+            response = CompletableFuture.completedFuture(responseFactory.failedLoginAttempts403());
             blocked = true;
         } else if (rateLimitGuard.shouldPreventRequest(requestedPath, accessAddress)) {
-            response = responseFactory.failedRateLimit403();
+            response = CompletableFuture.completedFuture(responseFactory.failedRateLimit403());
             blocked = true;
         } else if (!webserverConfiguration.getAllowedIpList().isAllowed(accessAddress)) {
             webserverConfiguration.getWebserverLogMessages()
                     .warnAboutWhitelistBlock(accessAddress, internalRequest.getRequestedURIString());
-            response = responseFactory.ipWhitelist403(accessAddress);
+            response = CompletableFuture.completedFuture(responseFactory.ipWhitelist403(accessAddress));
         } else {
-            try {
-                request = internalRequest.toRequest(accessAddress);
-                response = attemptToResolve(request, accessAddress);
-            } catch (WebUserAuthException thrownByAuthentication) {
-                response = processFailedAuthentication(internalRequest, accessAddress, thrownByAuthentication);
-            }
+            request = internalRequest.toRequest(accessAddress);
+            response = attemptToResolve(request, accessAddress)
+                    .exceptionallyCompose(throwable -> {
+                        Throwable cause = throwable;
+                        while (cause instanceof java.util.concurrent.CompletionException || cause instanceof java.util.concurrent.ExecutionException) {
+                            if (cause.getCause() != null) {
+                                cause = cause.getCause();
+                            } else {
+                                break;
+                            }
+                        }
+                        if (cause instanceof WebUserAuthException thrownByAuthentication) {
+                            return CompletableFuture.completedFuture(
+                                    processFailedAuthentication(internalRequest, accessAddress, thrownByAuthentication));
+                        }
+                        return CompletableFuture.failedFuture(throwable);
+                    });
         }
 
-        response.getHeaders().putIfAbsent("Access-Control-Allow-Origin", webserverConfiguration.getAllowedCorsOrigin());
-        response.getHeaders().putIfAbsent("Access-Control-Allow-Methods", "GET, OPTIONS");
-        response.getHeaders().putIfAbsent("Access-Control-Allow-Credentials", "true");
-        response.getHeaders().putIfAbsent("X-Robots-Tag", "noindex, nofollow");
+        response.whenComplete((r, e) -> {
+            if (r != null) {
+                Map<String, String> headers = r.getHeaders();
+                headers.putIfAbsent("Access-Control-Allow-Origin", webserverConfiguration.getAllowedCorsOrigin());
+                headers.putIfAbsent("Access-Control-Allow-Methods", "GET, OPTIONS");
+                headers.putIfAbsent("Access-Control-Allow-Credentials", "true");
+                headers.putIfAbsent("X-Robots-Tag", "noindex, nofollow");
+            }
+        });
 
         if (!blocked) {
-            accessLogger.log(internalRequest, request, response);
+            final Request doneRequest = request;
+            response.whenComplete((r, e) -> accessLogger.log(internalRequest, doneRequest, r));
         }
 
         return response;
     }
 
-    private Response attemptToResolve(@Untrusted Request request, @Untrusted String accessAddress) {
-        Response response = protocolUpgradeResponse(request)
-                .orElseGet(() -> responseResolver.getResponse(request));
-        request.getUser().ifPresent(user -> processSuccessfulLogin(response.getCode(), accessAddress));
+    private CompletableFuture<Response> attemptToResolve(@Untrusted Request request, @Untrusted String accessAddress) {
+        CompletableFuture<Response> response;
+        try {
+            response = protocolUpgradeResponse(request)
+                    .orElseGet(() -> responseResolver.getResponse(request));
+        } catch (Throwable t) {
+            response = responseResolver.handleException(request, t);
+        }
+        response.whenComplete((r, e) -> {
+            if (r != null) {
+                request.getUser().ifPresent(user -> processSuccessfulLogin(r.getCode(), accessAddress));
+            }
+        });
         return response;
     }
 
-    private Optional<Response> protocolUpgradeResponse(@Untrusted Request request) {
+    private Optional<CompletableFuture<Response>> protocolUpgradeResponse(@Untrusted Request request) {
         @Untrusted Optional<String> upgrade = request.getHeader(HttpHeader.UPGRADE.asString());
         if (upgrade.isPresent()) {
             @Untrusted String value = upgrade.get();
             if ("h2c".equals(value) || "h2".equals(value)) {
-                return Optional.of(Response.builder()
+                return Optional.of(CompletableFuture.completedFuture(Response.builder()
                         .setStatus(101)
                         .setHeader("Connection", HttpHeader.UPGRADE.asString())
                         .setHeader(HttpHeader.UPGRADE.asString(), value)
-                        .build());
+                        .build()));
             }
         }
         return Optional.empty();

--- a/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/resolver/json/query/QueryJSONResolver.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/delivery/webserver/resolver/json/query/QueryJSONResolver.java
@@ -26,8 +26,8 @@ import com.djrapitops.plan.delivery.formatting.Formatter;
 import com.djrapitops.plan.delivery.formatting.Formatters;
 import com.djrapitops.plan.delivery.rendering.json.PlayersTableJSONCreator;
 import com.djrapitops.plan.delivery.rendering.json.graphs.GraphJSONCreator;
+import com.djrapitops.plan.delivery.web.resolver.AsyncResolver;
 import com.djrapitops.plan.delivery.web.resolver.MimeType;
-import com.djrapitops.plan.delivery.web.resolver.Resolver;
 import com.djrapitops.plan.delivery.web.resolver.Response;
 import com.djrapitops.plan.delivery.web.resolver.exception.BadRequestException;
 import com.djrapitops.plan.delivery.web.resolver.request.Request;
@@ -37,6 +37,7 @@ import com.djrapitops.plan.delivery.webserver.cache.JSONStorage;
 import com.djrapitops.plan.extension.implementation.storage.queries.ExtensionQueryResultTableDataQuery;
 import com.djrapitops.plan.identification.ServerInfo;
 import com.djrapitops.plan.identification.ServerUUID;
+import com.djrapitops.plan.processing.Processing;
 import com.djrapitops.plan.settings.config.PlanConfig;
 import com.djrapitops.plan.settings.config.paths.DisplaySettings;
 import com.djrapitops.plan.settings.config.paths.TimeSettings;
@@ -70,13 +71,15 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 @Path("/v1/query")
-public class QueryJSONResolver implements Resolver {
+public class QueryJSONResolver implements AsyncResolver {
 
     private final QueryFilters filters;
 
+    private final Processing processing;
     private final PlanConfig config;
     private final DBSystem dbSystem;
     private final ServerInfo serverInfo;
@@ -89,6 +92,7 @@ public class QueryJSONResolver implements Resolver {
     @Inject
     public QueryJSONResolver(
             QueryFilters filters,
+            Processing processing,
             PlanConfig config,
             DBSystem dbSystem,
             ServerInfo serverInfo, JSONStorage jsonStorage,
@@ -98,6 +102,7 @@ public class QueryJSONResolver implements Resolver {
             Gson gson
     ) {
         this.filters = filters;
+        this.processing = processing;
         this.config = config;
         this.dbSystem = dbSystem;
         this.serverInfo = serverInfo;
@@ -134,32 +139,38 @@ public class QueryJSONResolver implements Resolver {
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = InputQueryDto.class)))
     )
     @Override
-    public Optional<Response> resolve(Request request) {
-        return Optional.of(getResponse(request));
+    public CompletableFuture<Optional<Response>> resolveAsync(Request request) {
+        return getResponse(request);
     }
 
-    private Response getResponse(@Untrusted Request request) {
+    private CompletableFuture<Optional<Response>> getResponse(@Untrusted Request request) {
         Optional<WebUser> user = request.getUser();
         boolean canAccessCache = user.map(u -> u.hasPermission(WebPermission.ACCESS_QUERY)).orElse(true);
-        Optional<Response> cachedResult = canAccessCache ? checkForCachedResult(request) : Optional.empty();
-        if (cachedResult.isPresent()) return cachedResult.get();
-
-        InputQueryDto inputQuery = parseInputQuery(request);
-        @Untrusted List<InputFilterDto> queries = inputQuery.getFilters();
-
-        // Check user has permission for the filter if login is enabled.
-        if (user.isPresent()) {
-            Optional<Response> errorResponse = checkFilterPermissions(queries, user.get());
-            if (errorResponse.isPresent()) {
-                return errorResponse.get();
+        if (canAccessCache) {
+            Optional<Response> cached = checkForCachedResult(request);
+            if (cached.isPresent()) {
+                return CompletableFuture.completedFuture(cached);
             }
         }
 
-        Filter.Result result = filters.apply(queries);
-        List<Filter.ResultPath> resultPath = result.getInverseResultPath();
-        Collections.reverse(resultPath);
+        return request.getRequestBodyAsync().thenCompose(bodyBytes -> {
+            InputQueryDto inputQuery = parseInputQuery(request, bodyBytes);
+            List<InputFilterDto> queries = inputQuery.getFilters();
 
-        return buildAndStoreResponse(inputQuery, result, resultPath);
+            if (user.isPresent()) {
+                Optional<Response> errorResponse = checkFilterPermissions(queries, user.get());
+                if (errorResponse.isPresent()) {
+                    return CompletableFuture.completedFuture(errorResponse);
+                }
+            }
+
+            return CompletableFuture.supplyAsync(() -> {
+                Filter.Result result = filters.apply(queries);
+                List<Filter.ResultPath> resultPath = result.getInverseResultPath();
+                Collections.reverse(resultPath);
+                return Optional.of(buildAndStoreResponse(inputQuery, result, resultPath));
+            }, processing.getNonCriticalExecutor());
+        });
     }
 
     private Optional<Response> checkFilterPermissions(List<InputFilterDto> queries, WebUser user) {
@@ -203,11 +214,11 @@ public class QueryJSONResolver implements Resolver {
         }
     }
 
-    private InputQueryDto parseInputQuery(@Untrusted Request request) {
-        if (request.getRequestBody().length == 0) {
+    private InputQueryDto parseInputQuery(@Untrusted Request request, byte[] bodyBytes) {
+        if (bodyBytes.length == 0) {
             return parseInputQueryFromQueryParams(request);
         } else {
-            return RequestBodyConverter.bodyJson(request, gson, InputQueryDto.class);
+            return RequestBodyConverter.bodyJson(bodyBytes, gson, InputQueryDto.class);
         }
     }
 

--- a/Plan/common/src/main/java/com/djrapitops/plan/processing/Processing.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/processing/Processing.java
@@ -213,4 +213,8 @@ public class Processing implements SubSystem {
     public Executor getCriticalExecutor() {
         return criticalExecutor;
     }
+
+    public ExecutorService getNonCriticalExecutor() {
+        return nonCriticalExecutor;
+    }
 }

--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/database/Database.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/database/Database.java
@@ -28,6 +28,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
 /**
@@ -163,6 +164,8 @@ public interface Database {
 
     int getTransactionQueueSize();
 
+    Async async();
+
     /**
      * Possible State changes:
      * CLOSED to PATCHING (Database init),
@@ -176,5 +179,33 @@ public interface Database {
         PATCHING,
         OPEN,
         CLOSING
+    }
+
+    public static class Async {
+        private final Database database;
+        private final ExecutorService executorService;
+
+        public Async(Database database, ExecutorService executorService) {
+            this.database = database;
+            this.executorService = executorService;
+        }
+
+        public <T> CompletableFuture<T> query(Query<T> query) {
+            return CompletableFuture.supplyAsync(() -> database.query(query), executorService);
+        }
+
+        public <T> CompletableFuture<Optional<T>> queryOptional(String sql, RowExtractor<T> rowExtractor, Object... parameters) {
+            return CompletableFuture.supplyAsync(() -> database.queryOptional(sql, rowExtractor, parameters), executorService);
+        }
+
+        public <T> CompletableFuture<List<T>> queryList(String sql, RowExtractor<T> rowExtractor, Object... parameters) {return CompletableFuture.supplyAsync(() -> database.queryList(sql, rowExtractor, parameters), executorService);}
+
+        public <T> CompletableFuture<Set<T>> querySet(String sql, RowExtractor<T> rowExtractor, Object... parameters) {return CompletableFuture.supplyAsync(() -> database.querySet(sql, rowExtractor, parameters), executorService);}
+
+        public <C extends Collection<T>, T> CompletableFuture<C> queryCollection(String sql, RowExtractor<T> rowExtractor, Supplier<C> collectionConstructor, Object... parameters) {return CompletableFuture.supplyAsync(() -> database.queryCollection(sql, rowExtractor, collectionConstructor, parameters), executorService);}
+
+        public <K, V> CompletableFuture<Map<K, V>> queryMap(String sql, MapRowExtractor<K, V> rowExtractor, Object... parameters) {return CompletableFuture.supplyAsync(() -> database.queryMap(sql, rowExtractor, parameters), executorService);}
+
+        public <M extends Map<K, V>, K, V> CompletableFuture<M> queryMap(String sql, MapRowExtractor<K, V> rowExtractor, Supplier<M> mapConstructor, Object... parameters) {return CompletableFuture.supplyAsync(() -> database.queryMap(sql, rowExtractor, mapConstructor, parameters), executorService);}
     }
 }

--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/database/MySQLDB.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/database/MySQLDB.java
@@ -20,6 +20,7 @@ import com.djrapitops.plan.exceptions.database.DBInitException;
 import com.djrapitops.plan.exceptions.database.DBOpException;
 import com.djrapitops.plan.exceptions.database.MariaDB11Exception;
 import com.djrapitops.plan.identification.ServerInfo;
+import com.djrapitops.plan.processing.Processing;
 import com.djrapitops.plan.settings.config.PlanConfig;
 import com.djrapitops.plan.settings.config.paths.DatabaseSettings;
 import com.djrapitops.plan.settings.locale.Locale;
@@ -67,7 +68,8 @@ public class MySQLDB extends SQLDB {
             RunnableFactory runnableFactory,
             PluginLogger pluginLogger,
             ErrorLogger errorLogger,
-            ApplicationDependencyManager applicationDependencyManager
+            ApplicationDependencyManager applicationDependencyManager,
+            Processing processing
     ) {
         super(
                 () -> serverInfo.get().getServerUUID(),
@@ -77,7 +79,8 @@ public class MySQLDB extends SQLDB {
                 runnableFactory,
                 pluginLogger,
                 errorLogger,
-                applicationDependencyManager
+                applicationDependencyManager,
+                processing
         );
     }
 

--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/database/SQLDB.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/database/SQLDB.java
@@ -21,6 +21,7 @@ import com.djrapitops.plan.exceptions.database.DBInitException;
 import com.djrapitops.plan.exceptions.database.DBOpException;
 import com.djrapitops.plan.exceptions.database.FatalDBException;
 import com.djrapitops.plan.identification.ServerUUID;
+import com.djrapitops.plan.processing.Processing;
 import com.djrapitops.plan.settings.config.PlanConfig;
 import com.djrapitops.plan.settings.config.paths.PluginSettings;
 import com.djrapitops.plan.settings.config.paths.TimeSettings;
@@ -78,6 +79,7 @@ public abstract class SQLDB extends AbstractDatabase {
     protected final PluginLogger logger;
     protected final ErrorLogger errorLogger;
     protected final ApplicationDependencyManager applicationDependencyManager;
+    private final Processing processing;
     private final Supplier<ServerUUID> serverUUIDSupplier;
     private final AtomicInteger transactionQueueSize = new AtomicInteger(0);
     private final AtomicBoolean dropUnimportantTransactions = new AtomicBoolean(false);
@@ -85,6 +87,7 @@ public abstract class SQLDB extends AbstractDatabase {
     protected ClassLoader driverClassLoader;
     private Supplier<ExecutorService> transactionExecutorServiceProvider;
     private ExecutorService transactionExecutor;
+    private Async async;
 
     protected SQLDB(
             Supplier<ServerUUID> serverUUIDSupplier,
@@ -94,7 +97,8 @@ public abstract class SQLDB extends AbstractDatabase {
             RunnableFactory runnableFactory,
             PluginLogger logger,
             ErrorLogger errorLogger,
-            ApplicationDependencyManager applicationDependencyManager
+            ApplicationDependencyManager applicationDependencyManager,
+            Processing processing
     ) {
         this.serverUUIDSupplier = serverUUIDSupplier;
         this.locale = locale;
@@ -104,6 +108,7 @@ public abstract class SQLDB extends AbstractDatabase {
         this.logger = logger;
         this.errorLogger = errorLogger;
         this.applicationDependencyManager = applicationDependencyManager;
+        this.processing = processing;
 
         this.transactionExecutorServiceProvider = () -> {
             String nameFormat = "Plan " + getClass().getSimpleName() + "-transaction-thread-%d";
@@ -355,10 +360,9 @@ public abstract class SQLDB extends AbstractDatabase {
             if (throwable == null) {
                 return CompletableFuture.completedFuture(null);
             }
-            if (throwable.getCause() instanceof FatalDBException) {
+            if (throwable.getCause() instanceof FatalDBException actual) {
                 ranIntoFatalError.set(true);
                 logger.error("Database failed to open, " + transaction.getClass().getName() + " failed to be executed.");
-                FatalDBException actual = (FatalDBException) throwable.getCause();
                 Optional<String> whatToDo = actual.getContext().flatMap(ErrorContext::getWhatToDo);
                 whatToDo.ifPresentOrElse(
                         message -> logger.error("What to do: " + message),
@@ -428,5 +432,13 @@ public abstract class SQLDB extends AbstractDatabase {
     @Override
     public int getTransactionQueueSize() {
         return transactionQueueSize.get();
+    }
+
+    @Override
+    public Async async() {
+        if (async == null) {
+            async = new Async(this, processing.getNonCriticalExecutor());
+        }
+        return async;
     }
 }

--- a/Plan/common/src/main/java/com/djrapitops/plan/storage/database/SQLiteDB.java
+++ b/Plan/common/src/main/java/com/djrapitops/plan/storage/database/SQLiteDB.java
@@ -18,6 +18,7 @@ package com.djrapitops.plan.storage.database;
 
 import com.djrapitops.plan.exceptions.database.DBInitException;
 import com.djrapitops.plan.identification.ServerInfo;
+import com.djrapitops.plan.processing.Processing;
 import com.djrapitops.plan.settings.config.PlanConfig;
 import com.djrapitops.plan.settings.locale.Locale;
 import com.djrapitops.plan.settings.locale.lang.PluginLang;
@@ -70,7 +71,8 @@ public class SQLiteDB extends SQLDB {
             RunnableFactory runnableFactory,
             PluginLogger logger,
             ErrorLogger errorLogger,
-            ApplicationDependencyManager applicationDependencyManager
+            ApplicationDependencyManager applicationDependencyManager,
+            Processing processing
     ) {
         super(
                 () -> serverInfo.get().getServerUUID(),
@@ -80,7 +82,8 @@ public class SQLiteDB extends SQLDB {
                 runnableFactory,
                 logger,
                 errorLogger,
-                applicationDependencyManager
+                applicationDependencyManager,
+                processing
         );
         dbName = databaseFile.getName();
         this.databaseFile = databaseFile;
@@ -246,6 +249,7 @@ public class SQLiteDB extends SQLDB {
         private final PlanConfig config;
         private final Lazy<ServerInfo> serverInfo;
         private final RunnableFactory runnableFactory;
+        private final Processing processing;
         private final PluginLogger logger;
         private final ErrorLogger errorLogger1;
         private final PlanFiles files;
@@ -257,7 +261,7 @@ public class SQLiteDB extends SQLDB {
                 PlanConfig config,
                 PlanFiles files,
                 Lazy<ServerInfo> serverInfo,
-                RunnableFactory runnableFactory,
+                RunnableFactory runnableFactory, Processing processing,
                 PluginLogger logger,
                 ErrorLogger errorLogger1,
                 ApplicationDependencyManager applicationDependencyManager
@@ -267,6 +271,7 @@ public class SQLiteDB extends SQLDB {
             this.files = files;
             this.serverInfo = serverInfo;
             this.runnableFactory = runnableFactory;
+            this.processing = processing;
             this.logger = logger;
             this.errorLogger1 = errorLogger1;
             this.applicationDependencyManager = applicationDependencyManager;
@@ -284,7 +289,9 @@ public class SQLiteDB extends SQLDB {
             return new SQLiteDB(databaseFile,
                     locale, config, files, serverInfo,
                     runnableFactory, logger, errorLogger1,
-                    applicationDependencyManager
+                    applicationDependencyManager,
+                    processing
+
             );
         }
 

--- a/Plan/extensions/adventure/build.gradle
+++ b/Plan/extensions/adventure/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 }
 
 compileJava {
-    options.release = 11
+    options.release = 17
 }
 
 tasks.named("shadowJar", ShadowJar) {

--- a/Plan/extensions/build.gradle
+++ b/Plan/extensions/build.gradle
@@ -49,5 +49,5 @@ dependencies {
 }
 
 compileJava {
-    options.release = 11
+    options.release = 17
 }

--- a/Plan/nukkit/build.gradle
+++ b/Plan/nukkit/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 }
 
 compileJava {
-    options.release = 11
+    options.release = 17
 }
 
 processResources {


### PR DESCRIPTION
### Description

This PR migrates to Jetty 12 and Java 17.

I'd like to implement support for the non-blocking APIs Jetty 12 adds before merging this, since it would let the webserver handle more requests rather than waiting for IO operations like reading files or database

Related issues:
- #4021 